### PR TITLE
attach dispose cache

### DIFF
--- a/morphia/src/main/java/com/google/code/morphia/mapping/EmbeddedMapper.java
+++ b/morphia/src/main/java/com/google/code/morphia/mapping/EmbeddedMapper.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import com.google.code.morphia.mapping.cache.DisposeEntityCache;
 import com.google.code.morphia.mapping.cache.EntityCache;
 import com.google.code.morphia.utils.IterHelper;
 import com.google.code.morphia.utils.IterHelper.MapIterCallback;
@@ -20,7 +21,8 @@ import com.mongodb.DBObject;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 class EmbeddedMapper implements CustomMapper {
-  public void toDBObject(final Object entity, final MappedField mf, final DBObject dbObject, final Map<Object, DBObject> involvedObjects,
+	protected EntityCache disposedCache = new DisposeEntityCache();
+    public void toDBObject(final Object entity, final MappedField mf, final DBObject dbObject, final Map<Object, DBObject> involvedObjects,
     final Mapper mapper) {
     final String name = mf.getNameToStore();
 
@@ -149,7 +151,7 @@ class EmbeddedMapper implements CustomMapper {
               refObj = mapper.converters.decode(mf.getType(), dbVal, mf);
             } else {
               refObj = mapper.getOptions().objectFactory.createInstance(mapper, mf, ((DBObject) dbVal));
-              refObj = mapper.fromDb(((DBObject) dbVal), refObj, cache);
+              refObj = mapper.fromDb(((DBObject) dbVal), refObj, disposedCache);
             }
             if (refObj != null) {
               mf.setFieldValue(entity, refObj);

--- a/morphia/src/main/java/com/google/code/morphia/mapping/cache/DisposeEntityCache.java
+++ b/morphia/src/main/java/com/google/code/morphia/mapping/cache/DisposeEntityCache.java
@@ -1,0 +1,46 @@
+/**
+ *
+ */
+package com.google.code.morphia.mapping.cache;
+
+import com.google.code.morphia.Key;
+
+/**
+ * キャッシュしません
+ * @author Shoichi <nisin.lib@gmail.com>
+ *
+ */
+public class DisposeEntityCache implements EntityCache {
+	private final EntityCacheStatistics stats = new EntityCacheStatistics();
+
+	public Boolean exists(Key<?> k) {
+		stats.misses++;
+		return false;
+	}
+
+	public void notifyExists(Key<?> k, boolean exists) {
+	}
+
+	public <T> T getEntity(Key<T> k) {
+		stats.misses++;
+		return null;
+	}
+
+	public <T> T getProxy(Key<T> k) {
+		stats.misses++;
+		return null;
+	}
+
+	public <T> void putProxy(Key<T> k, T t) {}
+
+	public <T> void putEntity(Key<T> k, T t) {}
+
+	public void flush() {
+		stats.reset();
+	}
+
+	public EntityCacheStatistics stats() {
+		return stats.copy();
+	}
+
+}


### PR DESCRIPTION
when sub object have @Id field then mapper generate only origin-version object .
my project's history document have same version of reference object .
this fix happen no additional db-access .
