### PR TITLE
logger order chenge

### DIFF
--- a/morphia/src/main/java/com/google/code/morphia/logging/MorphiaLoggerFactory.java
+++ b/morphia/src/main/java/com/google/code/morphia/logging/MorphiaLoggerFactory.java
@@ -12,8 +12,10 @@ import com.google.code.morphia.logging.jdk.JDKLoggerFactory;
 public final class MorphiaLoggerFactory {
   private static LogrFactory loggerFactory;
 
-  private static final List<String> factories = new ArrayList(Arrays.asList(JDKLoggerFactory.class.getName(),
-    "com.google.code.morphia.logging.slf4j.SLF4JLogrImplFactory"));
+  private static List<String> factories = new ArrayList(Arrays.asList(
+     "com.google.code.morphia.logging.slf4j.SLF4JLogrImplFactory",
+     JDKLoggerFactory.class.getName()
+     ));
 
   private static synchronized void init() {
     if (loggerFactory == null) {


### PR DESCRIPTION
fixed the logger order cause the jdk logger had been selected always.

the original code's order had been selected jdk logger anytime .
but I hope to use slf4j logger . jdk logger is just match of position are last item.
