### PR TITLE
Reduce hard dependencies and casts on QueryImpl

### DIFF
--- a/morphia/src/main/java/com/google/code/morphia/DatastoreImpl.java
+++ b/morphia/src/main/java/com/google/code/morphia/DatastoreImpl.java
@@ -184,8 +184,7 @@ public class DatastoreImpl implements AdvancedDatastore {
     return delete(query, getWriteConcern(query.getEntityClass()));
   }
 
-  public <T> WriteResult delete(final Query<T> query, final WriteConcern wc) {
-    final QueryImpl<T> q = (QueryImpl<T>) query;
+  public <T> WriteResult delete(final Query<T> q, final WriteConcern wc) {
 
     DBCollection dbColl = q.getCollection();
     //TODO remove this after testing.
@@ -1107,9 +1106,8 @@ public class DatastoreImpl implements AdvancedDatastore {
     return update(query, ops, createIfMissing, multi, getWriteConcern(query.getEntityClass()));
   }
 
-  private <T> UpdateResults<T> update(final Query<T> query, final DBObject u, final boolean createIfMissing, final boolean multi,
+  private <T> UpdateResults<T> update(final Query<T> qi, final DBObject u, final boolean createIfMissing, final boolean multi,
       final WriteConcern wc) {
-    final QueryImpl<T> qi = (QueryImpl<T>) query;
 
     DBCollection dbColl = qi.getCollection();
     //TODO remove this after testing.
@@ -1149,14 +1147,13 @@ public class DatastoreImpl implements AdvancedDatastore {
     return new UpdateResults<T>(wr);
   }
 
-  public <T> T findAndDelete(final Query<T> query) {
-    DBCollection dbColl = ((QueryImpl<T>) query).getCollection();
+  public <T> T findAndDelete(final Query<T> qi) {
+    DBCollection dbColl = qi.getCollection();
     //TODO remove this after testing.
     if (dbColl == null) {
-      dbColl = getCollection(query.getEntityClass());
+      dbColl = getCollection(qi.getEntityClass());
     }
-
-    final QueryImpl<T> qi = ((QueryImpl<T>) query);
+    
     final EntityCache cache = createCache();
 
     if (LOG.isTraceEnabled()) {
@@ -1180,9 +1177,8 @@ public class DatastoreImpl implements AdvancedDatastore {
     return findAndModify(query, ops, oldVersion, false);
   }
 
-  public <T> T findAndModify(final Query<T> query, final UpdateOperations<T> ops, final boolean oldVersion, final boolean createIfMissing) {
-    final QueryImpl<T> qi = (QueryImpl<T>) query;
-
+  public <T> T findAndModify(final Query<T> qi, final UpdateOperations<T> ops, final boolean oldVersion, final boolean createIfMissing) {
+    
     DBCollection dbColl = qi.getCollection();
     //TODO remove this after testing.
     if (dbColl == null) {
@@ -1210,15 +1206,14 @@ public class DatastoreImpl implements AdvancedDatastore {
   }
 
   @SuppressWarnings("rawtypes")
-  public <T> MapreduceResults<T> mapReduce(final MapreduceType type, final Query q, final Class<T> outputType,
+  public <T> MapreduceResults<T> mapReduce(final MapreduceType type, final Query qi, final Class<T> outputType,
       final MapReduceCommand baseCommand) {
 
     Assert.parametersNotNull("map", baseCommand.getMap());
     Assert.parameterNotEmpty(baseCommand.getMap(), "map");
     Assert.parametersNotNull("reduce", baseCommand.getReduce());
     Assert.parameterNotEmpty(baseCommand.getMap(), "reduce");
-
-    final QueryImpl<T> qi = (QueryImpl<T>) q;
+    
     if (qi.getOffset() != 0 || qi.getFieldsObject() != null) {
       throw new QueryException("mapReduce does not allow the offset/retrievedFields query options.");
     }
@@ -1273,10 +1268,9 @@ public class DatastoreImpl implements AdvancedDatastore {
   }
 
   @SuppressWarnings("rawtypes")
-  public <T> MapreduceResults<T> mapReduce(final MapreduceType type, final Query query, final String map, final String reduce,
+  public <T> MapreduceResults<T> mapReduce(final MapreduceType type, final Query qi, final String map, final String reduce,
       final String finalize, final Map<String, Object> scopeFields, final Class<T> outputType) {
-
-    final QueryImpl<T> qi = (QueryImpl<T>) query;
+    
     final DBCollection dbColl = qi.getCollection();
 
     final String outColl = mapper.getCollectionName(outputType);
@@ -1314,7 +1308,7 @@ public class DatastoreImpl implements AdvancedDatastore {
       cmd.setScope(scopeFields);
     }
 
-    return mapReduce(type, query, outputType, cmd);
+    return mapReduce(type, qi, outputType, cmd);
   }
 
   /**

--- a/morphia/src/main/java/com/google/code/morphia/query/Query.java
+++ b/morphia/src/main/java/com/google/code/morphia/query/Query.java
@@ -2,6 +2,9 @@ package com.google.code.morphia.query;
 
 
 import org.bson.types.CodeWScope;
+
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
 import com.mongodb.ReadPreference;
 
 
@@ -161,7 +164,54 @@ public interface Query<T> extends QueryResults<T>, Cloneable {
    */
   String toString();
 
+  /**
+   * Returns the entity {@link Class}.
+   */
   Class<T> getEntityClass();
+  
+  /**
+   * Returns the offset.
+   * 
+   * @see #offset(int)
+   */
+  int getOffset();
+  
+  /**
+   * Returns the limit
+   * 
+   * @see #limit(int)
+   */
+  int getLimit();
+  
+  /**
+   * Returns the batch size
+   * 
+   * @see #batchSize(int)
+   */
+  int getBatchSize();
+  
+  /**
+   * Returns the Mongo query {@link DBObject}.
+   */
+  DBObject getQueryObject();
+  
+  /**
+   * Returns the Mongo sort {@link DBObject}.
+   */
+  DBObject getSortObject();
+  
+  /**
+   * Returns the Mongo fields {@link DBObject}.
+   */
+  DBObject getFieldsObject();
+  
+  /**
+   * Returns the {@link DBCollection} of the {@link Query}.
+   */
+  DBCollection getCollection();
 
+  /**
+   * Creates and returns a copy of this {@link Query}.
+   */
   Query<T> clone();
 }

--- a/morphia/src/main/java/com/google/code/morphia/query/QueryImpl.java
+++ b/morphia/src/main/java/com/google/code/morphia/query/QueryImpl.java
@@ -287,12 +287,14 @@ public class QueryImpl<T> extends CriteriaContainerImpl implements Query<T> {
 
     public List<T> asList() {
         final List<T> results = new ArrayList<T>();
-        final MorphiaIterator<T, T> iter = (MorphiaIterator<T, T>) fetch().iterator();
-        for (final T ent : iter) {
+        
+        final Iterable<T> elements = fetch();
+        for (final T ent : elements) {
             results.add(ent);
         }
 
-        if (log.isTraceEnabled()) {
+        if (log.isTraceEnabled() && (elements instanceof MorphiaIterator<?, ?>)) {
+            MorphiaIterator<?, ?> iter = (MorphiaIterator<?, ?>)elements;
             log.trace(String.format("asList: %s \t %d entities, iterator time: driver %n ms, mapper %n ms \n\t cache: %s \n\t for %s",
                 dbColl.getName(), results.size(), iter.getDriverTime(), iter.getMapperTime(), cache.stats().toString(), getQueryObject()));
         }


### PR DESCRIPTION
This change removes all QueryImpl casts from DatastoreImpl. There is also a change to the QueryImpl#asList() method not to make a unchecked cast for MorphiaIterator (the log statement is questionable IMO).
