### PR TITLE
Bug fix for embedded complex custom types

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/mapping/EmbeddedMapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/EmbeddedMapper.java
@@ -139,12 +139,12 @@ class EmbeddedMapper implements CustomMapper {
 
         final Object dbVal = mf.getDbObjectValue(dbObject);
         if (dbVal != null) {
-          final boolean isDBObject = dbVal instanceof DBObject && !(dbVal instanceof BasicDBList);
+          final boolean isDBObject = dbVal instanceof DBObject;
 
           //run converters
           if (isDBObject && (mapper.getConverters().hasDbObjectConverter(mf) 
                              || mapper.getConverters().hasDbObjectConverter(mf.getType()))) {
-            mapper.getConverters().fromDBObject(((DBObject) dbVal), mf, entity);
+            mapper.getConverters().fromDBObject(dbObject, mf, entity);
           } else {
             Object refObj;
             if (mapper.getConverters().hasSimpleValueConverter(mf) || mapper.getConverters().hasSimpleValueConverter(mf.getType())) {

--- a/morphia/src/test/java/org/mongodb/morphia/converters/CustomConverterInEmbedTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/converters/CustomConverterInEmbedTest.java
@@ -4,7 +4,9 @@ package org.mongodb.morphia.converters;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mongodb.morphia.TestBase;
+import org.mongodb.morphia.annotations.Converters;
 import org.mongodb.morphia.mapping.MappedField;
+import org.mongodb.morphia.mapping.MappingException;
 import org.mongodb.morphia.testutil.TestEntity;
 
 import java.util.HashMap;
@@ -12,6 +14,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
 
 /**
  * @author Uwe Schaefer
@@ -97,6 +105,160 @@ public class CustomConverterInEmbedTest extends TestBase {
         Assert.assertFalse(e.foo.isEmpty());
         Assert.assertTrue(e.foo.containsKey("bar"));
         Assert.assertEquals("bar", e.foo.get("bar").string);
+    }
+
+    /**
+     * A type that contains a complex custom type, represented as an object.
+     * 
+     * @author Christian Trimble
+     */
+    @Converters(ComplexFooConverter.class)
+    public static class ComplexBar extends TestEntity {
+        private static final long serialVersionUID = 1L;
+        public ComplexFoo foo;
+    }
+
+    /**
+     * A type that contains a complex custom type, represented as an array.
+     * 
+     * @author Christian Trimble
+     */
+    @Converters(ComplexArrayFooConverter.class)
+    public static class ArrayBar extends TestEntity {
+        private static final long serialVersionUID = 1L;
+        public ArrayFoo foo;
+    }
+
+    /**
+     * A complex embedded type, represented as an object
+     * 
+     * @author Christian Trimble
+     */
+    public static class ComplexFoo {
+        private String first;
+        private String second;
+
+        ComplexFoo() {
+        }
+
+        public ComplexFoo(final String first, final String second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        String first() {
+            return first;
+        }
+
+        String second() {
+            return second;
+        }
+    }
+
+    /**
+     * A complex embedded type, represented as an array
+     * 
+     * @author Christian Trimble
+     */
+    public static class ArrayFoo {
+        private String first;
+        private String second;
+
+        ArrayFoo() {
+        }
+
+        public ArrayFoo(final String first, final String second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        String first() {
+            return first;
+        }
+
+        String second() {
+            return second;
+        }
+    }
+
+    /**
+     * A converter that does not implement SimpleValueConverter and converts
+     * ComplexFoo into an object type.
+     * 
+     * @author Christian Trimble
+     */
+    public static class ComplexFooConverter extends TypeConverter {
+        public ComplexFooConverter() {
+            super(ComplexFoo.class);
+        }
+
+        @Override
+        public Object decode(final Class targetClass, final Object fromDBObject, final MappedField optionalExtraInfo) throws MappingException {
+            DBObject dbObject = (DBObject) fromDBObject;
+            return new ComplexFoo((String) dbObject.get("first"), (String) dbObject.get("second"));
+        }
+
+        @Override
+        public Object encode(final Object value, final MappedField optionalExtraInfo) {
+            ComplexFoo complex = (ComplexFoo) value;
+            BasicDBObject dbObject = new BasicDBObject();
+            dbObject.put("first", complex.first());
+            dbObject.put("second", complex.second());
+            return dbObject;
+        }
+    }
+
+    /**
+     * A converter that does not implement SimpleValueConverter and converts
+     * ArrayFoo into an array type.
+     * 
+     * @author Christian Trimble
+     */
+    public static class ComplexArrayFooConverter extends TypeConverter {
+        public ComplexArrayFooConverter() {
+            super(ArrayFoo.class);
+        }
+
+        @Override
+        public Object decode(final Class targetClass, final Object fromDBObject, final MappedField optionalExtraInfo) throws MappingException {
+            BasicDBList dbObject = (BasicDBList) fromDBObject;
+            return new ArrayFoo((String) dbObject.get(1), (String) dbObject.get(2));
+        }
+
+        @Override
+        public Object encode(final Object value, final MappedField optionalExtraInfo) {
+            ArrayFoo complex = (ArrayFoo) value;
+            BasicDBList dbObject = new BasicDBList();
+            dbObject.put(1, complex.first());
+            dbObject.put(2, complex.second());
+            return dbObject;
+        }
+    }
+
+    @Test
+    public void testEmbeddedComplexType() throws Exception {
+        ComplexBar bar = new ComplexBar();
+        bar.foo = new ComplexFoo("firstValue", "secondValue");
+        getDs().save(bar);
+
+        ComplexBar fromDb = getDs().get(ComplexBar.class, bar.getId());
+        assertThat("bar is not null", fromDb, notNullValue());
+        assertThat("foo is not null", fromDb.foo, notNullValue());
+        assertThat("foo has the correct first value", fromDb.foo.first(), equalTo("firstValue"));
+        assertThat("foo has the correct second value", fromDb.foo.second(), equalTo("secondValue"));
+    }
+
+    @Test
+    public void testEmbeddedComplexArrayType() throws Exception {
+        ArrayBar bar = new ArrayBar();
+        bar.foo = new ArrayFoo("firstValue", "secondValue");
+        getDs().save(bar);
+
+        ArrayBar fromDb = getDs().get(ArrayBar.class, bar.getId());
+        assertThat("bar is not null", fromDb, notNullValue());
+        assertThat("foo is not null", fromDb.foo, notNullValue());
+        assertThat("foo has the correct first value", fromDb.foo.first(), equalTo("firstValue"));
+        assertThat("foo has the correct second value", fromDb.foo.second(), equalTo("secondValue"));
     }
 
 }


### PR DESCRIPTION
The EmbeddedMapper was passing field values to DefaultConverters.fromDBObject(DBObject, MappedField, Object), when there was no SimpleTypeConverter defined for the type.  However, this method assumes that DBObject is the object containing the field.  Embedded complex custom types were failing, due to this double application of the mapped field.
