### PR TITLE
New constructor for configuring own mapper class

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/Morphia.java
+++ b/morphia/src/main/java/org/mongodb/morphia/Morphia.java
@@ -49,6 +49,15 @@ public class Morphia {
   public Morphia() {
     this(Collections.<Class>emptySet());
   }
+  
+  /**
+   * Constrauctor to configure your own mapper
+   * @param myMapper
+   */
+  public Morphia( final Mapper myMapper) {
+    this(Collections.<Class>emptySet());
+    mapper = myMapper;
+  }
 
   public Morphia(final Set<Class> classesToMap) {
     mapper = new Mapper();


### PR DESCRIPTION
We used to use our own mapper class, which is a bit more robust by catching some mapping exceptions occuring when communication in special with PHP.
After switching from jmkgreen we noticed that we have no possibility to define our own mapper in morphia. This pull request will re-enable this feature.
