### PR TITLE
Fixes / Should fix the issue 377

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/converters/DefaultConverters.java
+++ b/morphia/src/main/java/org/mongodb/morphia/converters/DefaultConverters.java
@@ -151,6 +151,13 @@ public class DefaultConverters {
 
     List<TypeConverter> tcs = null;
 
+    // 1st check for @Serialized etc.:
+    for (final TypeConverter tc : untypedTypeEncoders) {
+      if (tc.canHandle(mf) || (val != null && tc.isSupported(val.getClass(), mf))) {
+        return tc;
+      }
+    }
+
     if (val != null) {
       tcs = tcMap.get(val.getClass());
     }
@@ -165,12 +172,12 @@ public class DefaultConverters {
       }
       return tcs.get(0);
     }
-
-    for (final TypeConverter tc : untypedTypeEncoders) {
-      if (tc.canHandle(mf) || (val != null && tc.isSupported(val.getClass(), mf))) {
-        return tc;
-      }
-    }
+// moved up:
+//    for (final TypeConverter tc : untypedTypeEncoders) {
+//      if (tc.canHandle(mf) || (val != null && tc.isSupported(val.getClass(), mf))) {
+//        return tc;
+//      }
+//    }
     if (passthroughConverter.canHandle(mf) || (val != null && passthroughConverter.isSupported(val.getClass(), mf))) {
       return passthroughConverter;
     }
@@ -179,6 +186,14 @@ public class DefaultConverters {
   }
 
   private TypeConverter getEncoder(final Class c) {
+
+    // Moving up necessary here as well?
+    for (final TypeConverter tc : untypedTypeEncoders) {
+      if (tc.canHandle(c)) {
+        return tc;
+      }
+    }
+    
     final List<TypeConverter> tcs = tcMap.get(c);
     if (tcs != null) {
       if (tcs.size() > 1) {
@@ -186,12 +201,12 @@ public class DefaultConverters {
       }
       return tcs.get(0);
     }
-
-    for (final TypeConverter tc : untypedTypeEncoders) {
-      if (tc.canHandle(c)) {
-        return tc;
-      }
-    }
+// moved up:
+//    for (final TypeConverter tc : untypedTypeEncoders) {
+//      if (tc.canHandle(c)) {
+//        return tc;
+//      }
+//    }
     if (passthroughConverter.canHandle(c)) {
       return passthroughConverter;
     }

--- a/morphia/src/test/java/org/mongodb/morphia/issue377/TestMapping.java
+++ b/morphia/src/test/java/org/mongodb/morphia/issue377/TestMapping.java
@@ -1,0 +1,57 @@
+package org.mongodb.morphia.issue377;
+
+import org.bson.types.ObjectId;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mongodb.morphia.TestBase;
+import org.mongodb.morphia.annotations.Entity;
+import org.mongodb.morphia.annotations.Id;
+import org.mongodb.morphia.annotations.Serialized;
+import org.mongodb.morphia.dao.BasicDAO;
+import org.mongodb.morphia.mapping.Mapper;
+import org.mongodb.morphia.mapping.cache.DefaultEntityCache;
+
+import com.mongodb.DBObject;
+
+
+/**
+ * Unit test for testing morphia mappings with Serialized
+ */
+public class TestMapping extends TestBase {
+
+    @Test
+    public void testMapping() {
+        final BasicDAO<User, ObjectId> messageDAO = new BasicDAO<User, ObjectId>(User.class, getDs());
+        Assert.assertNotNull(messageDAO);
+        
+        Mapper mapper = new Mapper();
+
+        User user = new User();
+        user.id = 1;
+
+        user.userObject = "just a String";
+        DBObject dbObject = mapper.toDBObject(user);
+        Object object = mapper.fromDBObject(User.class, dbObject, new DefaultEntityCache());
+        Assert.assertEquals(user.userObject, ((User) object).userObject);
+        
+        user.userObject = 33;
+        dbObject = mapper.toDBObject(user);
+        object = mapper.fromDBObject(User.class, dbObject, new DefaultEntityCache());
+        Assert.assertEquals(user.userObject, ((User) object).userObject);
+
+        user.userObject = 33.3;
+        dbObject = mapper.toDBObject(user);
+        object = mapper.fromDBObject(User.class, dbObject, new DefaultEntityCache());
+        Assert.assertEquals(user.userObject, ((User) object).userObject);
+    }
+
+
+    @Entity
+    private static class User {
+        @Id
+        private Integer id;
+        
+        @Serialized
+        private Object userObject;
+    }
+}


### PR DESCRIPTION
See http://code.google.com/p/morphia/issues/detail?can=2&start=0&num=100&q=&colspec=ID%20Type%20Stars%20Status%20Priority%20Milestone%20Owner%20Summary&groupby=&sort=&id=377

Encoding and decoding of entity properties happen not fully under same ruleset. As a matter of this reading data from MongoDB fails under following condition:
- Entity having a property of type 'Object' with @Serialized entity. 
- If you save a simple object, e.g. a String or an Integer for this property the object is saved by means of the default/typed encoders. This means the value is saved as String / Integer in the DB.
- When reading the database the Morphia code tries to deserialize the object which fails with a MappingException. (Difference is here that DefaultEncoders#getEncoder with value=null is called. Thus it relies on the @Serialized annotation.)

Some points about my fix:
- If there is a property with @Serialized annotation, I prefer to have it saved as _serialized_ object nevertheless Morphia would be able to map directly. This means @Serialized annotion should have priority.
- I am not sure if I found all necessary places where the fix is necessary.
- issue377.TestMapping contains some very simple test cases to check the fix.
