### PR TITLE
honor storeEmpties mapper option for maps

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/converters/MapOfValuesConverter.java
+++ b/morphia/src/main/java/org/mongodb/morphia/converters/MapOfValuesConverter.java
@@ -56,7 +56,7 @@ public class MapOfValuesConverter extends TypeConverter {
         }
 
         final Map<Object, Object> map = (Map<Object, Object>) value;
-        if (!map.isEmpty()) {
+        if (!map.isEmpty() || getMapper().getOptions().isStoreEmpties()) {
             final Map mapForDb = new HashMap();
             for (final Map.Entry<Object, Object> entry : map.entrySet()) {
                 final String strKey = converters.encode(entry.getKey()).toString();

--- a/morphia/src/test/java/org/mongodb/morphia/mapping/MapperOptionsTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/mapping/MapperOptionsTest.java
@@ -11,6 +11,8 @@ import org.mongodb.morphia.annotations.Id;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 
 /**
@@ -24,6 +26,15 @@ public class MapperOptionsTest extends TestBase {
         private List<String> names = new ArrayList<String>();
 
         HasList() {
+        }
+    }
+
+    private static class HasMap implements Serializable {
+        @Id
+        private ObjectId id = new ObjectId();
+        private Map<String, String> properties = new HashMap<String, String>();
+
+        HasMap() {
         }
     }
 
@@ -47,5 +58,27 @@ public class MapperOptionsTest extends TestBase {
         getDs().save(hl);
         dbObj = getDs().getCollection(HasList.class).findOne();
         Assert.assertFalse("field exists, value =" + dbObj.get("names"), dbObj.containsField("names"));
+    }
+
+    @Test
+    public void emptyMapStoredWithOptions() throws Exception {
+        final HasMap hm = new HasMap();
+
+        //Test default behavior
+        getDs().save(hm);
+        DBObject dbObj = getDs().getCollection(HasMap.class).findOne();
+        Assert.assertFalse("field exists, value =" + dbObj.get("properties"), dbObj.containsField("properties"));
+
+        //Test default storing empty map with storeEmpties option
+        getMorphia().getMapper().getOptions().setStoreEmpties(true);
+        getDs().save(hm);
+        dbObj = getDs().getCollection(HasMap.class).findOne();
+        Assert.assertTrue("field missing", dbObj.containsField("properties"));
+
+        //Test opposite from above
+        getMorphia().getMapper().getOptions().setStoreEmpties(false);
+        getDs().save(hm);
+        dbObj = getDs().getCollection(HasMap.class).findOne();
+        Assert.assertFalse("field exists, value =" + dbObj.get("properties"), dbObj.containsField("properties"));
     }
 }


### PR DESCRIPTION
Currently, an empty map is not stored in mongo, even when mapper.storeEmpties = true

This causes issues when null != {} in equality checks, meaning an object saved and then immediately fetched will not be equal to the original object.
