### PR TITLE
Implement max/min support

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/query/Query.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/Query.java
@@ -112,7 +112,8 @@ public interface Query<T> extends QueryResults<T>, Cloneable {
    * <p>
    * to build a constraint on index {@code {"a", "b"}}
    * </p>
-   * @see <a href="http://docs.mongodb.org/manual/reference/operator/meta/max/#op._S_max">http://docs.mongodb.org/manual/reference/operator/meta/max/#op._S_max</a>
+   * @see <a href="http://docs.mongodb.org/manual/reference/operator/meta/max/#op._S_max">
+   *     http://docs.mongodb.org/manual/reference/operator/meta/max/#op._S_max</a>
    * @param field The index field to constrain.
    * @param value The exclusive upper bound.
    */
@@ -132,7 +133,8 @@ public interface Query<T> extends QueryResults<T>, Cloneable {
    * <p>
    * to build a constraint on index {@code {"a", "b"}}
    * </p>
-   * @see <a href="http://docs.mongodb.org/manual/reference/operator/meta/min/#op._S_min">http://docs.mongodb.org/manual/reference/operator/meta/min/#op._S_min</a>
+   * @see <a href="http://docs.mongodb.org/manual/reference/operator/meta/min/#op._S_min">
+   *     http://docs.mongodb.org/manual/reference/operator/meta/min/#op._S_min</a>
    * @param field The index field to constrain.
    * @param value The inclusive lower bound.
    */

--- a/morphia/src/main/java/org/mongodb/morphia/query/QueryImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/QueryImpl.java
@@ -465,7 +465,7 @@ public class QueryImpl<T> extends CriteriaContainerImpl implements Query<T> {
         return this;
     }
 
-    public Query<T> max(String field, Object value) {
+    public Query<T> max(final String field, final Object value) {
         if (max == null) {
             max = new BasicDBObject();
         }
@@ -475,7 +475,7 @@ public class QueryImpl<T> extends CriteriaContainerImpl implements Query<T> {
         return this;
     }
 
-    public Query<T> min(String field, Object value) {
+    public Query<T> min(final String field, final Object value) {
         if (min == null) {
             min = new BasicDBObject();
         }

--- a/morphia/src/test/java/org/mongodb/morphia/query/TestMaxMin.java
+++ b/morphia/src/test/java/org/mongodb/morphia/query/TestMaxMin.java
@@ -21,13 +21,13 @@ public class TestMaxMin extends TestBase {
             @Index("testField"),
             @Index("testField, _id")
     })
-    private static class IndexedEntity {
+    private static final class IndexedEntity {
 
         @Id
         private ObjectId id;
         private String testField;
 
-        private IndexedEntity(String testField) {
+        private IndexedEntity(final String testField) {
             this.testField = testField;
         }
 


### PR DESCRIPTION
Add support for max and min:
http://docs.mongodb.org/manual/reference/operator/meta/max/#op._S_max
http://docs.mongodb.org/manual/reference/operator/meta/min/#op._S_min

Fixes #497
