### PR TITLE
Fixed broken build and added a getter for ValidatorFactory in

### DIFF
--- a/entityscanner-plug/pom.xml
+++ b/entityscanner-plug/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.mongodb.morphia</groupId>
     <artifactId>morphia-parent</artifactId>
-    <version>0.106-SNAPSHOT</version>
+    <version>0.107-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   <artifactId>morphia-entityscanner-plug</artifactId>

--- a/guice-plug/pom.xml
+++ b/guice-plug/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
     <groupId>org.mongodb.morphia</groupId>
     <artifactId>morphia-parent</artifactId>
-		<version>0.106-SNAPSHOT</version>
+		<version>0.107-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>morphia-guice-plug</artifactId>

--- a/gwt/pom.xml
+++ b/gwt/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
     	<groupId>org.mongodb.morphia</groupId>
     	<artifactId>morphia-parent</artifactId>
-		<version>0.106-SNAPSHOT</version>
+		<version>0.107-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 

--- a/jrebel-plug/pom.xml
+++ b/jrebel-plug/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
     <groupId>org.mongodb.morphia</groupId>
     <artifactId>morphia-parent</artifactId>
-		<version>0.106-SNAPSHOT</version>
+		<version>0.107-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>morphia-jrebel-plug</artifactId>

--- a/logging-slf4j/pom.xml
+++ b/logging-slf4j/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
     <groupId>org.mongodb.morphia</groupId>
     <artifactId>morphia-parent</artifactId>
-		<version>0.106-SNAPSHOT</version>
+		<version>0.107-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 

--- a/morphia/pom.xml
+++ b/morphia/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.mongodb.morphia</groupId>
         <artifactId>morphia-parent</artifactId>
-        <version>0.106-SNAPSHOT</version>
+        <version>0.107-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/no-proxy-deps-tests/pom.xml
+++ b/no-proxy-deps-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.mongodb.morphia</groupId>
         <artifactId>morphia-parent</artifactId>
-        <version>0.106-SNAPSHOT</version>
+        <version>0.107-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.mongodb.morphia</groupId>
     <artifactId>morphia-parent</artifactId>
-    <version>0.106-SNAPSHOT</version>
+    <version>0.107-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/validation/src/main/java/org/mongodb/morphia/ValidationExtension.java
+++ b/validation/src/main/java/org/mongodb/morphia/ValidationExtension.java
@@ -37,4 +37,8 @@ public class ValidationExtension extends AbstractEntityInterceptor {
             throw new VerboseJSR303ConstraintViolationException(validate);
         }
     }
+
+    public ValidatorFactory getValidatorFactory() {
+        return this.validationFactory;
+    }
 }


### PR DESCRIPTION
ValidationExtension

Commit dc4f82575434467756b01ec9f2c2804008ac750a changed
morphia-parent to 0.107 while left children at 0.106. This change
fixes it.

Also added a getValidation method in ValidationExtension see
https://github.com/mongodb/morphia/issues/573
