### PR TITLE
LocaleConverter fix for incomplete locales

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/converters/LocaleConverter.java
+++ b/morphia/src/main/java/org/mongodb/morphia/converters/LocaleConverter.java
@@ -1,50 +1,48 @@
 package org.mongodb.morphia.converters;
 
-
 import org.mongodb.morphia.mapping.MappedField;
 
 import java.util.Locale;
 
-
-/**
- * @author Uwe Schaefer, (us@thomas-daily.de)
- * @author scotthernandez
- */
 public class LocaleConverter extends TypeConverter implements SimpleValueConverter {
 
-  public LocaleConverter() {
-    super(Locale.class);
-  }
-
-  @Override
-  public Object decode(final Class targetClass, final Object fromDBObject, final MappedField optionalExtraInfo) {
-    return parseLocale(fromDBObject.toString());
-  }
-
-  @Override
-  public Object encode(final Object val, final MappedField optionalExtraInfo) {
-    if (val == null) {
-      return null;
+    public LocaleConverter() {
+        super(Locale.class);
     }
 
-    return val.toString();
-  }
-
-  public static Locale parseLocale(final String localeString) {
-    if ((localeString != null) && (localeString.length() != 0)) {
-      final int index = localeString.indexOf("_");
-      final int index2 = localeString.indexOf("_", index + 1);
-      Locale l;
-      if (index == -1) {
-          l = new Locale(localeString);
-      } else if (index2 == -1) {
-          l = new Locale(localeString.substring(0, index), localeString.substring(index + 1));
-      } else {
-          l = new Locale(localeString.substring(0, index), localeString.substring(index + 1, index2), localeString.substring(index2 + 1));
-      }
-      return l;
+    @Override
+    public Object decode(final Class targetClass, final Object fromDBObject, final MappedField optionalExtraInfo) {
+        return parseLocale(fromDBObject.toString());
     }
-    
-    return null;
-  }
+
+    @Override
+    public Object encode(final Object val, final MappedField optionalExtraInfo) {
+        if (val == null) {
+            return null;
+        }
+
+        return val.toString();
+    }
+
+    public static Locale parseLocale(final String localeString) {
+        if ((localeString != null) && (localeString.length() != 0)) {
+            final int index = localeString.indexOf("_");
+            final int index2 = localeString.indexOf("_", index + 1);
+            Locale resultLocale;
+            if (index == -1) {
+                resultLocale = new Locale(localeString);
+            } else if (index2 == -1) {
+                resultLocale = new Locale(localeString.substring(0, index), localeString.substring(index + 1));
+            } else {
+                resultLocale = new Locale(
+                        localeString.substring(0, index),
+                        localeString.substring(index + 1, index2),
+                        localeString.substring(index2 + 1));
+
+            }
+            return resultLocale;
+        }
+
+        return null;
+    }
 }

--- a/morphia/src/test/java/org/mongodb/morphia/converters/LocaleConverterTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/converters/LocaleConverterTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class LocaleConverterTest extends TestBase {
+
     @Test
     public void shouldEncodeAndDecodeBuiltInLocale() throws Exception {
         // given
@@ -36,5 +37,57 @@ public class LocaleConverterTest extends TestBase {
         assertThat(decodedLocale.getLanguage(), is("de"));
         assertThat(decodedLocale.getCountry(), is("DE"));
         assertThat(decodedLocale.getVariant(), is("bavarian"));
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeCountryOnlyLocale() {
+        // given
+        LocaleConverter converter = new LocaleConverter();
+        Locale expectedLocale = new Locale("", "FI");
+
+        // when
+        Locale decodedLocale = (Locale) converter.decode(Locale.class, converter.encode(expectedLocale));
+
+        // then
+        assertThat(decodedLocale, is(expectedLocale));
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeNoCountryLocale() {
+        // given
+        LocaleConverter converter = new LocaleConverter();
+        Locale expectedLocale = new Locale("fi", "", "VAR");
+
+        // when
+        Locale decodedLocale = (Locale) converter.decode(Locale.class, converter.encode(expectedLocale));
+
+        // then
+        assertThat(decodedLocale, is(expectedLocale));
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeNoLanguageLocale() {
+        // given
+        LocaleConverter converter = new LocaleConverter();
+        Locale expectedLocale = new Locale("", "FI", "VAR");
+
+        // when
+        Locale decodedLocale = (Locale) converter.decode(Locale.class, converter.encode(expectedLocale));
+
+        // then
+        assertThat(decodedLocale, is(expectedLocale));
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeSpecialVariantLocale() {
+        // given
+        LocaleConverter converter = new LocaleConverter();
+        Locale expectedLocale = new Locale("fi", "FI", "VAR_SPECIAL");
+
+        // when
+        Locale decodedLocale = (Locale) converter.decode(Locale.class, converter.encode(expectedLocale));
+
+        // then
+        assertThat(decodedLocale, is(expectedLocale));
     }
 }


### PR DESCRIPTION
LocaleConverter wasn't able to decode properly "incomplete" locales such as: "new Locale("", "XX")".
Added tests and a fix for the converter.
