### PR TITLE
Projection expressions with single arguments e.g. {"$size": "$source"}

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipelineImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipelineImpl.java
@@ -242,21 +242,21 @@ public class AggregationPipelineImpl implements AggregationPipeline {
         } else if (projection.getSource() != null) {
             return new BasicDBObject(target, projection.getSource());
         } else if (projection.getArguments() != null) {
-        	DBObject args = toExpressionArgs(projection.getArguments());
+            DBObject args = toExpressionArgs(projection.getArguments());
             if (target == null) {
-            	// Unwrap for single-argument expressions
-            	if (args instanceof List<?> && ((List<?>) args).size() == 1) {
-            		Object firstArg = ((List<?>) args).get(0);
-            		if (firstArg instanceof DBObject) {
-            			return (DBObject) firstArg;
-            		}
-            	}
+                // Unwrap for single-argument expressions
+                if (args instanceof List<?> && ((List<?>) args).size() == 1) {
+                    Object firstArg = ((List<?>) args).get(0);
+                    if (firstArg instanceof DBObject) {
+                        return (DBObject) firstArg;
+                    }
+                }
                 return args;
             } else {
-            	// Unwrap for single-argument expressions
-            	if (args instanceof List<?> && ((List<?>) args).size() == 1) {
-            		return new BasicDBObject(target, ((List<?>) args).get(0));
-            	}
+                // Unwrap for single-argument expressions
+                if (args instanceof List<?> && ((List<?>) args).size() == 1) {
+                    return new BasicDBObject(target, ((List<?>) args).get(0));
+                }
                 return new BasicDBObject(target, args);
             }
         } else {

--- a/morphia/src/main/java/org/mongodb/morphia/aggregation/Projection.java
+++ b/morphia/src/main/java/org/mongodb/morphia/aggregation/Projection.java
@@ -142,7 +142,7 @@ public final class  Projection {
 
     /**
      * Counts and returns the total the number of items in an array
-     * 
+     *
      * @param expression The argument for $size can be any expression as long as it resolves to an array.
      * @return the projection
      * @mongodb.driver.manual reference/operator/aggregation/size $size

--- a/morphia/src/main/java/org/mongodb/morphia/aggregation/Projection.java
+++ b/morphia/src/main/java/org/mongodb/morphia/aggregation/Projection.java
@@ -141,6 +141,17 @@ public final class  Projection {
     }
 
     /**
+     * Counts and returns the total the number of items in an array
+     * 
+     * @param expression The argument for $size can be any expression as long as it resolves to an array.
+     * @return the projection
+     * @mongodb.driver.manual reference/operator/aggregation/size $size
+     */
+    public static Projection size(final Object expression) {
+        return expression("$size", expression);
+    }
+
+    /**
      * Creates a modulo projection
      *
      * @param arg1 subtraction argument


### PR DESCRIPTION
After #667 was merged, expressions could be composed such as

`Projection.expression("$size", Projection.projection("field"))`

Which would be translated to:

`{"$size": ["$field"]}`

Though `$size` only accepts a single argument, an array containing a single string is also accepted.

After @e95cdc3271408000bc57cf8f94c9468de55f1c43 ([Location of change](https://github.com/mongodb/morphia/commit/e95cdc3271408000bc57cf8f94c9468de55f1c43#diff-b8c970e87e213b797b5f99cabb700305R262)) a check was added to unwrap single-argument expressions, but it assumes that the type of the argument is a `DBObject`. This fails in the above case, where the argument is a projection reference string.

This PR adds a helper method for `$size` projection expressions, and a corresponding test to make sure the argument is unwrapped correctly from the arguments list.

The fix for the `ClassCastException` moves the unwrapping check to the caller of `toExpressionArgs` so that the string value can be handled without a cast to DBObject causing an exception.