### PR TITLE
fix the call getCursor error

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/query/MorphiaIterator.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/MorphiaIterator.java
@@ -1,6 +1,7 @@
 package org.mongodb.morphia.query;
 
 
+import com.mongodb.Cursor;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import org.mongodb.morphia.Datastore;
@@ -70,10 +71,10 @@ public class MorphiaIterator<T, V> implements Iterable<V>, Iterator<V> {
     }
 
     /**
-     * @return the underlying DBCursor
+     * @return the underlying Cursor
      */
-    public DBCursor getCursor() {
-        return (DBCursor) wrapped;
+    public Cursor getCursor() {
+        return (Cursor) wrapped;
     }
 
     /**


### PR DESCRIPTION
When call the getCursor function, it will throw the following exception, just need to use the com.mongodb.Cursor to solve this problem.
java.lang.ClassCastException: com.mongodb.MongoCursorAdapter cannot be cast to com.mongodb.DBCursor
	at org.mongodb.morphia.query.MorphiaIterator.getCursor(MorphiaIterator.java:76)