### PR TITLE
Fix for ensureIndexes() logic

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/IndexHelper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/IndexHelper.java
@@ -164,7 +164,9 @@ final class IndexHelper {
                 List<MappedClass> classes = new ArrayList<MappedClass>();
                 MappedClass mappedClass = mapper.getMappedClass(mf.isSingleValue() ? mf.getType() : mf.getSubClass());
                 classes.add(mappedClass);
-                classes.addAll(mapper.getSubTypes(mappedClass));
+                if (mappedClass.isInterface() || mappedClass.isAbstract()) {
+                    classes.addAll(mapper.getSubTypes(mappedClass));
+                }
                 for (MappedClass aClass : classes) {
                     for (Index index : collectIndexes(aClass, parents)) {
                         List<Field> fields = new ArrayList<Field>();

--- a/morphia/src/test/java/org/mongodb/morphia/issue1175/EnsureIndexesTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/issue1175/EnsureIndexesTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import static org.mongodb.morphia.testutil.IndexMatcher.doesNotHaveIndexNamed;
 import static org.mongodb.morphia.testutil.IndexMatcher.hasIndexNamed;
 
+import java.util.Date;
 import java.util.List;
 
 import org.junit.Test;
@@ -13,6 +14,7 @@ import org.mongodb.morphia.annotations.Embedded;
 import org.mongodb.morphia.annotations.Entity;
 import org.mongodb.morphia.annotations.Id;
 import org.mongodb.morphia.annotations.Indexed;
+import org.mongodb.morphia.utils.IndexDirection;
 
 import com.mongodb.DBObject;
 
@@ -27,10 +29,11 @@ public class EnsureIndexesTest extends TestBase {
 
         // then
         List<DBObject> indexInfo = getDs().getCollection(Company.class).getIndexInfo();
-        assertEquals(3, indexInfo.size());
+        assertEquals(4, indexInfo.size());
         assertThat(indexInfo, hasIndexNamed("_id_"));
-        assertThat(indexInfo, hasIndexNamed("employees.employeeId_1"));
+        assertThat(indexInfo, hasIndexNamed("employees.birthday_-1"));
         assertThat(indexInfo, hasIndexNamed("employees.fullName_1"));
+        assertThat(indexInfo, hasIndexNamed("employees.employeeId_1"));
     }
 
     @Test
@@ -43,14 +46,21 @@ public class EnsureIndexesTest extends TestBase {
 
         // then
         List<DBObject> indexInfo = getDs().getCollection(Contract.class).getIndexInfo();
-        assertEquals(2, indexInfo.size());
+        assertEquals(3, indexInfo.size());
         assertThat(indexInfo, hasIndexNamed("_id_"));
+        assertThat(indexInfo, hasIndexNamed("person.birthday_-1"));
         assertThat(indexInfo, hasIndexNamed("person.fullName_1"));
         assertThat(indexInfo, doesNotHaveIndexNamed("person.employeeId_1"));
     }
 
     @Embedded
-    public static class Person {
+    public static class LivingBeing {
+        @Indexed(IndexDirection.DESC)
+        public Date birthday;
+    }
+
+    @Embedded
+    public static class Person extends LivingBeing {
         @Indexed
         public String fullName;
     }

--- a/morphia/src/test/java/org/mongodb/morphia/issue1175/EnsureIndexesTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/issue1175/EnsureIndexesTest.java
@@ -1,0 +1,81 @@
+package org.mongodb.morphia.issue1175;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mongodb.morphia.testutil.IndexMatcher.doesNotHaveIndexNamed;
+import static org.mongodb.morphia.testutil.IndexMatcher.hasIndexNamed;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.mongodb.morphia.TestBase;
+import org.mongodb.morphia.annotations.Embedded;
+import org.mongodb.morphia.annotations.Entity;
+import org.mongodb.morphia.annotations.Id;
+import org.mongodb.morphia.annotations.Indexed;
+
+import com.mongodb.DBObject;
+
+public class EnsureIndexesTest extends TestBase {
+    @Test
+    public final void ensureIndexesFromSuperclasses() {
+        // given
+        getMorphia().map(Person.class, Employee.class, Company.class);
+
+        // when
+        getAds().ensureIndexes();
+
+        // then
+        List<DBObject> indexInfo = getDs().getCollection(Company.class).getIndexInfo();
+        assertEquals(3, indexInfo.size());
+        assertThat(indexInfo, hasIndexNamed("_id_"));
+        assertThat(indexInfo, hasIndexNamed("employees.employeeId_1"));
+        assertThat(indexInfo, hasIndexNamed("employees.fullName_1"));
+    }
+
+    @Test
+    public final void ensureIndexesWithoutSubclasses() {
+        // given
+        getMorphia().map(Person.class, Employee.class, Contract.class);
+
+        // when
+        getAds().ensureIndexes();
+
+        // then
+        List<DBObject> indexInfo = getDs().getCollection(Contract.class).getIndexInfo();
+        assertEquals(2, indexInfo.size());
+        assertThat(indexInfo, hasIndexNamed("_id_"));
+        assertThat(indexInfo, hasIndexNamed("person.fullName_1"));
+        assertThat(indexInfo, doesNotHaveIndexNamed("person.employeeId_1"));
+    }
+
+    @Embedded
+    public static class Person {
+        @Indexed
+        public String fullName;
+    }
+
+    @Embedded
+    public static class Employee extends Person {
+        @Indexed
+        public Long employeeId;
+        public String title;
+    }
+
+    @Entity
+    public static class Contract {
+        @Id
+        public Long contractId;
+        public Long companyId;
+        @Embedded
+        public Person person;
+    }
+
+    @Entity
+    public static class Company {
+        @Id
+        public Long companyId;
+        @Embedded
+        public List<Employee> employees;
+    }
+}

--- a/morphia/src/test/java/org/mongodb/morphia/issue1175/EnsureIndexesTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/issue1175/EnsureIndexesTest.java
@@ -56,36 +56,36 @@ public class EnsureIndexesTest extends TestBase {
     @Embedded
     public static class LivingBeing {
         @Indexed(IndexDirection.DESC)
-        public Date birthday;
+        private Date birthday;
     }
 
     @Embedded
     public static class Person extends LivingBeing {
         @Indexed
-        public String fullName;
+        private String fullName;
     }
 
     @Embedded
     public static class Employee extends Person {
         @Indexed
-        public Long employeeId;
-        public String title;
+        private Long employeeId;
+        private String title;
     }
 
     @Entity
     public static class Contract {
         @Id
-        public Long contractId;
-        public Long companyId;
+        private Long contractId;
+        private Long companyId;
         @Embedded
-        public Person person;
+        private Person person;
     }
 
     @Entity
     public static class Company {
         @Id
-        public Long companyId;
+        private Long companyId;
         @Embedded
-        public List<Employee> employees;
+        private List<Employee> employees;
     }
 }


### PR DESCRIPTION
This pull-request should fix the issue #1175 

With this fix indexes from sub-classes will not be propagated on embedded field of a definite class and hence it will not raise an exception during key calculation. This should not break anybodies implementation since creation of indexes in such scenario is blocked anyway (see related issue #1175).

The indexes from sub-classes will be still propagated if class of embedded field is an `interface` or an `abstract class`, which make sense in its own way and it does not break key calculation logic. See corresponding integration test [IndexHelperTest.createIndex()](https://github.com/mongodb/morphia/blob/master/morphia/src/test/java/org/mongodb/morphia/IndexHelperTest.java#L119) where 6 indexes are expected, only 4 indexes are declared in direct classes 1 index is declared in parent class and 1 index is declared in sub-class.