### PR TITLE
Simple interface for discriminator persistence

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
@@ -442,7 +442,7 @@ public class DatastoreImpl implements AdvancedDatastore {
 
         Object id = key.getId();
         if (id instanceof DBObject) {
-            ((DBObject) id).removeField(Mapper.CLASS_NAME_FIELDNAME);
+            mapper.getOptions().getClassInfoPersister().removeClassInfo((DBObject) id);
         }
         return get(clazz, id);
     }

--- a/morphia/src/main/java/org/mongodb/morphia/ObjectFactory.java
+++ b/morphia/src/main/java/org/mongodb/morphia/ObjectFactory.java
@@ -1,6 +1,7 @@
 package org.mongodb.morphia;
 
 import com.mongodb.DBObject;
+import org.mongodb.morphia.mapping.classinfo.ClassInfoPersister;
 import org.mongodb.morphia.mapping.MappedField;
 import org.mongodb.morphia.mapping.Mapper;
 
@@ -22,8 +23,8 @@ public interface ObjectFactory {
     <T> T createInstance(Class<T> clazz);
 
     /**
-     * Creates an instance of the class defined in the {@link Mapper#CLASS_NAME_FIELDNAME} field in the dbObject passed in.  If that field
-     * is missing, the given Class is used instead.
+     * Creates an instance of the class as determined by the {@link ClassInfoPersister}.
+     * If the discriminator fails, the given Class is used instead.
      *
      * @param clazz type class to instantiate
      * @param dbObj the state to populate the new instance with
@@ -33,8 +34,9 @@ public interface ObjectFactory {
     <T> T createInstance(Class<T> clazz, DBObject dbObj);
 
     /**
-     * Creates an instance of the class defined in the {@link Mapper#CLASS_NAME_FIELDNAME} field in the dbObject passed in.  If that field
-     * is missing, morphia attempts to the MappedField to determine which concrete class to instantiate.
+     * Creates an instance of the class defined as determined by the {@link ClassInfoPersister}.
+     * If the discriminator fails, morphia attempts to use the MappedField to determine which concrete class to
+     * instantiate.
      *
      * @param mapper the Mapper to use
      * @param mf     the MappedField to consult when creating the instance

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/DefaultCreator.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/DefaultCreator.java
@@ -28,7 +28,14 @@ public class DefaultCreator implements ObjectFactory {
      * Creates a new DefaultCreator with no options
      */
     public DefaultCreator() {
-        classInfoPersister = new DefaultClassInfoPersister();
+        this(new DefaultClassInfoPersister());
+    }
+
+    /**
+     * @param mapperOptions the options to use
+     */
+    public DefaultCreator(final MapperOptions mapperOptions) {
+        this(mapperOptions.getClassInfoPersister());
     }
 
     /**

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/EmbeddedMapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/EmbeddedMapper.java
@@ -98,7 +98,7 @@ class EmbeddedMapper implements CustomMapper {
             final DBObject dbObj = fieldValue == null ? null : mapper.toDBObject(fieldValue, involvedObjects);
             if (dbObj != null) {
                 if (!shouldSaveClassName(fieldValue, dbObj, mf)) {
-                    dbObj.removeField(Mapper.CLASS_NAME_FIELDNAME);
+                    mapper.getOptions().getClassInfoPersister().removeClassInfo(dbObj);
                 }
 
                 if (!dbObj.keySet().isEmpty() || mapper.getOptions().isStoreEmpties()) {
@@ -240,7 +240,7 @@ class EmbeddedMapper implements CustomMapper {
                     }
 
                     if (!shouldSaveClassName(o, val, mf)) {
-                        ((DBObject) val).removeField(Mapper.CLASS_NAME_FIELDNAME);
+                        mapper.getOptions().getClassInfoPersister().removeClassInfo((DBObject) val);
                     }
 
                     values.add(val);
@@ -280,11 +280,11 @@ class EmbeddedMapper implements CustomMapper {
                             if (((List) val).get(0) instanceof DBObject) {
                                 List<DBObject> list = (List<DBObject>) val;
                                 for (DBObject o : list) {
-                                    o.removeField(Mapper.CLASS_NAME_FIELDNAME);
+                                    mapper.getOptions().getClassInfoPersister().removeClassInfo(o);
                                 }
                             }
                         } else {
-                            ((DBObject) val).removeField(Mapper.CLASS_NAME_FIELDNAME);
+                            mapper.getOptions().getClassInfoPersister().removeClassInfo((DBObject) val);
                         }
                     }
                 }

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
@@ -36,6 +36,7 @@ import org.mongodb.morphia.logging.Logger;
 import org.mongodb.morphia.logging.MorphiaLoggerFactory;
 import org.mongodb.morphia.mapping.cache.EntityCache;
 import org.mongodb.morphia.mapping.classinfo.ClassInfoPersister;
+import org.mongodb.morphia.mapping.classinfo.DefaultClassInfoPersister;
 import org.mongodb.morphia.mapping.lazy.LazyFeatureDependencies;
 import org.mongodb.morphia.mapping.lazy.LazyProxyFactory;
 import org.mongodb.morphia.mapping.lazy.proxy.ProxiedEntityReference;
@@ -82,6 +83,13 @@ public class Mapper {
      * Special name that can never be used. Used as default for some fields to indicate default state.
      */
     public static final String IGNORED_FIELDNAME = ".";
+
+    /**
+     * See {@link DefaultClassInfoPersister#DEFAULT_DISCRIMINATOR_FIELD_NAME}
+     */
+    @Deprecated
+    public static final String CLASS_NAME_FIELDNAME = DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME;
+
     private static final Logger LOG = MorphiaLoggerFactory.get(Mapper.class);
     /**
      * Set of classes that registered by this mapper

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/MapperOptions.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/MapperOptions.java
@@ -7,6 +7,8 @@ import org.mongodb.morphia.logging.Logger;
 import org.mongodb.morphia.logging.MorphiaLoggerFactory;
 import org.mongodb.morphia.mapping.cache.DefaultEntityCacheFactory;
 import org.mongodb.morphia.mapping.cache.EntityCacheFactory;
+import org.mongodb.morphia.mapping.classinfo.ClassInfoPersister;
+import org.mongodb.morphia.mapping.classinfo.DefaultClassInfoPersister;
 
 /**
  * Options to control mapping behavior.
@@ -25,9 +27,9 @@ public class MapperOptions {
     private boolean storeNulls;
     private boolean storeEmpties;
     private boolean useLowerCaseCollectionNames;
-    private boolean cacheClassLookups = false;
     private boolean mapSubPackages = false;
-    private ObjectFactory objectFactory = new DefaultCreator(this);
+    private ClassInfoPersister classInfoPersister = new DefaultClassInfoPersister();
+    private ObjectFactory objectFactory = new DefaultCreator(classInfoPersister);
     private EntityCacheFactory cacheFactory = new DefaultEntityCacheFactory();
     private CustomMapper embeddedMapper = new EmbeddedMapper();
     private CustomMapper defaultMapper = embeddedMapper;
@@ -59,6 +61,7 @@ public class MapperOptions {
         setDefaultMapper(options.getDefaultMapper());
         setReferenceMapper(options.getReferenceMapper());
         setValueMapper(options.getValueMapper());
+        setClassInfoPersister(options.getClassInfoPersister());
     }
 
     /**
@@ -205,7 +208,7 @@ public class MapperOptions {
      * @return true if Morphia should cache name -> Class lookups
      */
     public boolean isCacheClassLookups() {
-        return cacheClassLookups;
+        return classInfoPersister.isCaching();
     }
 
     /**
@@ -214,7 +217,7 @@ public class MapperOptions {
      * @param cacheClassLookups true if the lookup results should be cached
      */
     public void setCacheClassLookups(final boolean cacheClassLookups) {
-        this.cacheClassLookups = cacheClassLookups;
+        classInfoPersister.setCaching(cacheClassLookups);
     }
 
     /**
@@ -294,5 +297,19 @@ public class MapperOptions {
      */
     public void setMapSubPackages(final boolean mapSubPackages) {
         this.mapSubPackages = mapSubPackages;
+    }
+
+    /**
+     * @return the selected class info persister strategy
+     */
+    public ClassInfoPersister getClassInfoPersister() {
+        return classInfoPersister;
+    }
+
+    /**
+     * @param classInfoPersister the class info persister strategy to use
+     */
+    public void setClassInfoPersister(final ClassInfoPersister classInfoPersister) {
+        this.classInfoPersister = classInfoPersister;
     }
 }

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/ReferenceMapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/ReferenceMapper.java
@@ -321,7 +321,7 @@ class ReferenceMapper implements CustomMapper {
             id = dbRef.getId();
         }
         if (id instanceof DBObject) {
-            ((DBObject) id).removeField(Mapper.CLASS_NAME_FIELDNAME);
+            mapper.getOptions().getClassInfoPersister().removeClassInfo((DBObject) id);
         }
         refDbObject = collection.findOne(id);
 

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/Cacheable.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/Cacheable.java
@@ -1,0 +1,20 @@
+package org.mongodb.morphia.mapping.classinfo;
+
+/**
+ * Signifies that the implementing class <strong>may</strong> use in-memory caching which can be enabled or disabled.
+ */
+public interface Cacheable {
+
+    /**
+     * Enable or disable caching
+     *
+     * @param caching whether or not to cache
+     */
+    void setCaching(boolean caching);
+
+    /**
+     * @return whether or not the implementing type is currently caching values
+     */
+    boolean isCaching();
+
+}

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/ClassIdMapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/ClassIdMapper.java
@@ -1,0 +1,31 @@
+package org.mongodb.morphia.mapping.classinfo;
+
+/**
+ * A strategy interface for mapping from class id to type; may use in-memory caching and obeys {@link Cacheable}
+ *
+ * The following expression must <strong>always</strong> return true for any non-null result of {@code getId}
+ *
+ * <pre> val.getClass() == getClass(getId(val)) </pre>
+ */
+public interface ClassIdMapper extends Cacheable {
+
+    /**
+     * Get a class id for the type of the provided object.
+     *
+     * If returned, guaranteed to obey the above contract
+     *
+     * @param value the object for which a type id is desired
+     * @return the id for the type or null if it cannot be produced
+     */
+    String getId(Object value);
+
+    /**
+     * Returns a class for the provided ID if can be loaded.
+     *
+     * @param id the id to load
+     * @param <T> the expected class (or superclass); provided for casting convenience.
+     * @return the loaded class if found; otherwise null.
+     */
+    <T> Class<T> getClass(String id);
+
+}

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/ClassInfoPersister.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/ClassInfoPersister.java
@@ -1,0 +1,62 @@
+package org.mongodb.morphia.mapping.classinfo;
+
+import com.mongodb.DBObject;
+
+/**
+ * A strategy interface for persisting class information within {@link DBObject} so that they can be mapped to POJOs.
+ */
+public interface ClassInfoPersister extends Cacheable {
+
+    /**
+     * Add the information necessary to rehydrate the concrete class of this object
+     * @param entity the pojo
+     * @param dbObject the data to be serialized
+     * @param hint any e.g. super class of the type
+     */
+    void addClassInfo(Object entity, DBObject dbObject, Class<?> hint);
+
+    /**
+     * Load a class from class information stored within the object; return null if none found.
+     *
+     * @param <T> the desired type for convenience
+     * @param dbObject the data from which to load the class information
+     * @param hint any e.g. super class of the returned type if already known; not null
+     * @return the class object or null
+     */
+    <T> Class<T> getClass(DBObject dbObject, Class<?> hint);
+
+     /**
+     * Load a class from class information stored within the object; return null if none found.
+     *
+     * Likely to be called when mapping e.g. elemn of
+     *
+     * @param <T> the desired type for convenience
+     * @param dbObject the data from which to load the class information
+     * @return the class object or null
+     */
+    <T> Class<T> getClass(DBObject dbObject);
+
+    /**
+     * Remove any known class information stored within the data. If no info is present, this is a no-op.
+     *
+     * @param dbObject the data
+     * @param hint the type (or superclass thereof) expected to be represented by the data
+     */
+    void removeClassInfo(DBObject dbObject, Class<?> hint);
+
+    /**
+     * Remove any class information stored within the data. If no info is present, this is a no-op.
+     *
+     * @param dbObject the data
+     */
+    void removeClassInfo(DBObject dbObject);
+
+    /**
+     * Add class information to the provided projection
+     *
+     * @param projection the projection
+     * @param hint the class expected
+     */
+    void addClassInfoToProjection(DBObject projection, Class<?> hint);
+
+}

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/ClassNameClassIdMapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/ClassNameClassIdMapper.java
@@ -1,0 +1,78 @@
+package org.mongodb.morphia.mapping.classinfo;
+
+import org.mongodb.morphia.logging.Logger;
+import org.mongodb.morphia.logging.MorphiaLoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A {@link ClassIdMapper} which simply uses the full class name as a class id and can optionally cache the classes
+ * after load. This is designed for backward compatibility with older versions of Morphia.
+ */
+public class ClassNameClassIdMapper implements ClassIdMapper {
+
+    private static final Logger LOG = MorphiaLoggerFactory.get(ClassNameClassIdMapper.class);
+
+    private final Map<String, Class<?>> classNameCache = new ConcurrentHashMap<String, Class<?>>();
+    private boolean cacheClassLookUps;
+
+    @Override
+    public String getId(final Object value) {
+        return value.getClass().getName();
+    }
+
+    @Override
+    public <T> Class<T> getClass(final String id) {
+        @SuppressWarnings("unchecked")
+        Class<T> clazz = (Class<T>) (cacheClassLookUps ? getClassCached(id) : doGetClass(id));
+        return clazz;
+    }
+
+    private Class<?> doGetClass(final String className) {
+        try {
+            return Class.forName(
+                    className,
+                    true,
+                    Thread.currentThread().getContextClassLoader()
+            );
+        } catch (ClassNotFoundException e) {
+            if (LOG.isWarningEnabled()) {
+                LOG.warning("Class not found defined in dbObj: ", e);
+            }
+            return null;
+        }
+    }
+
+    private Class<?> getClassCached(final String className) {
+        final Class<?> cached = classNameCache.get(className);
+        if (cached != null) {
+            return cached;
+        }
+
+        final Class<?> loaded = doGetClass(className);
+        classNameCache.put(className, loaded);
+
+        return loaded;
+    }
+
+    @Override
+    public void setCaching(final boolean caching) {
+        this.cacheClassLookUps = caching;
+    }
+
+    @Override
+    public boolean isCaching() {
+        return cacheClassLookUps;
+    }
+
+    /**
+     * @return a copy of the current class name cache
+     * @deprecated unnecessarily published
+     */
+    @Deprecated
+    public Map<String, Class> getClassNameCache() {
+        return new HashMap<String, Class>(classNameCache);
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/DefaultClassInfoPersister.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/DefaultClassInfoPersister.java
@@ -1,0 +1,100 @@
+package org.mongodb.morphia.mapping.classinfo;
+
+import com.mongodb.DBObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@link ClassInfoPersister} that assumes that all class info is stored within one field and delegates to
+ * a {@link ClassIdMapper} to get and parse the value from that one field
+ */
+public class DefaultClassInfoPersister implements ClassInfoPersister {
+
+    /**
+     * Special field used by morphia to support various possibly loading issues; will be replaced when discriminators
+     * are implemented to support polymorphism
+     */
+    public static final String DEFAULT_DISCRIMINATOR_FIELD_NAME = "className";
+
+    private final String discriminatorFieldName;
+    private final ClassIdMapper classIdMapper;
+
+    /**
+     * Default constructor that provides backwards compatibility and uses {@link ClassNameClassIdMapper} and the
+     * standard {@link DefaultClassInfoPersister#DEFAULT_DISCRIMINATOR_FIELD_NAME}
+     * @see ClassNameClassIdMapper
+     */
+    public DefaultClassInfoPersister() {
+        this(DEFAULT_DISCRIMINATOR_FIELD_NAME, new ClassNameClassIdMapper());
+    }
+
+    /**
+     * Constructor that provides the ability to customize behavior with a different discriminator field and different
+     * id mapping logic.
+     *
+     * @param discriminatorFieldName the field in which to store the class id
+     * @param classIdMapper the strategy for producing a unique class id
+     * @see ClassIdMapper
+     */
+    public DefaultClassInfoPersister(final String discriminatorFieldName, final ClassIdMapper classIdMapper) {
+        this.discriminatorFieldName = discriminatorFieldName;
+        this.classIdMapper = classIdMapper;
+    }
+
+    @Override
+    public void addClassInfo(final Object entity, final DBObject dbObject, final Class<?> hint) {
+        dbObject.put(discriminatorFieldName, classIdMapper.getId(entity));
+    }
+
+    @Override
+    public <T> Class<T> getClass(final DBObject dbObject, final Class<?> hint) {
+        return getClass(dbObject); // ignore hint
+    }
+
+    @Override
+    public <T> Class<T> getClass(final DBObject dbObject) {
+        final String classId = (String) dbObject.get(discriminatorFieldName);
+        if (classId == null) {
+            return null;
+        }
+        return classIdMapper.getClass(classId);
+    }
+
+    @Override
+    public void setCaching(final boolean caching) {
+        classIdMapper.setCaching(caching);
+    }
+
+    @Override
+    public boolean isCaching() {
+        return classIdMapper.isCaching();
+    }
+
+    /**
+     * @return the cache of classnames
+     */
+    @Deprecated
+    public Map<String, Class> getClassCache() {
+        if (classIdMapper instanceof ClassNameClassIdMapper) {
+            return ((ClassNameClassIdMapper) classIdMapper).getClassNameCache();
+        }
+        return new HashMap<String, Class>();
+    }
+
+
+    @Override
+    public void removeClassInfo(final DBObject dbObject) {
+        dbObject.removeField(DEFAULT_DISCRIMINATOR_FIELD_NAME);
+    }
+
+    @Override
+    public void removeClassInfo(final DBObject dbObject, final Class<?> hint) {
+        removeClassInfo(dbObject); // ignore hint
+    }
+
+    @Override
+    public void addClassInfoToProjection(final DBObject projection, final Class<?> hint) {
+        projection.put(DEFAULT_DISCRIMINATOR_FIELD_NAME, 1);
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/FixedMapClassIdMapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/FixedMapClassIdMapper.java
@@ -1,0 +1,48 @@
+package org.mongodb.morphia.mapping.classinfo;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A simple class id mapper which delegates to a provided hash map
+ */
+public class FixedMapClassIdMapper implements ClassIdMapper {
+
+    private final Map<String, Class<?>> idToClass;
+    private final Map<Class<?>, String> classToId;
+
+    /**
+     * @param classToId the mapping of class to id
+     */
+    public FixedMapClassIdMapper(final Map<Class<?>, String> classToId) {
+        this.classToId = Collections.unmodifiableMap(new HashMap<Class<?>, String>(classToId));
+
+        final Map<String, Class<?>> idToClass = new HashMap<String, Class<?>>();
+        for (Map.Entry<Class<?>, String> entry : classToId.entrySet()) {
+            idToClass.put(entry.getValue(), entry.getKey());
+        }
+        this.idToClass = Collections.unmodifiableMap(idToClass);
+    }
+
+    @Override
+    public String getId(final Object value) {
+        return classToId.get(value.getClass());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Class<T> getClass(final String id) {
+        return (Class<T>) idToClass.get(id);
+    }
+
+    @Override
+    public void setCaching(final boolean caching) {
+        // no op
+    }
+
+    @Override
+    public boolean isCaching() {
+        return false;
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/package-info.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/classinfo/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * class info discrimination logic
+ */
+package org.mongodb.morphia.mapping.classinfo;

--- a/morphia/src/main/java/org/mongodb/morphia/query/QueryImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/QueryImpl.java
@@ -417,7 +417,7 @@ public class QueryImpl<T> extends CriteriaContainerImpl implements Query<T> {
         final BasicDBObject fieldsFilter = copy(projection);
 
         if (includeFields && entityAnnotation != null && !entityAnnotation.noClassnameStored()) {
-            fieldsFilter.put(Mapper.CLASS_NAME_FIELDNAME, 1);
+            ds.getMapper().getOptions().getClassInfoPersister().addClassInfoToProjection(fieldsFilter, clazz);
         }
 
         return fieldsFilter;

--- a/morphia/src/test/java/org/mongodb/morphia/TestMapping.java
+++ b/morphia/src/test/java/org/mongodb/morphia/TestMapping.java
@@ -29,10 +29,10 @@ import org.mongodb.morphia.annotations.Embedded;
 import org.mongodb.morphia.annotations.Entity;
 import org.mongodb.morphia.annotations.Id;
 import org.mongodb.morphia.annotations.Serialized;
-import org.mongodb.morphia.mapping.DefaultCreator;
 import org.mongodb.morphia.mapping.Mapper;
 import org.mongodb.morphia.mapping.MappingException;
 import org.mongodb.morphia.mapping.cache.DefaultEntityCache;
+import org.mongodb.morphia.mapping.classinfo.DefaultClassInfoPersister;
 import org.mongodb.morphia.testmodel.Address;
 import org.mongodb.morphia.testmodel.Article;
 import org.mongodb.morphia.testmodel.Circle;
@@ -141,20 +141,24 @@ public class TestMapping extends TestBase {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testBasicMapping() throws Exception {
         performBasicMappingTest();
-        final DefaultCreator objectFactory = (DefaultCreator) getMorphia().getMapper().getOptions().getObjectFactory();
-        assertTrue(objectFactory.getClassNameCache().isEmpty());
+        final DefaultClassInfoPersister classDiscriminator = (DefaultClassInfoPersister) getMorphia()
+                .getMapper().getOptions().getClassInfoPersister();
+        assertTrue(classDiscriminator.getClassCache().isEmpty());
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testBasicMappingWithCachedClasses() throws Exception {
         getMorphia().getMapper().getOptions().setCacheClassLookups(true);
         try {
             performBasicMappingTest();
-            final DefaultCreator objectFactory = (DefaultCreator) getMorphia().getMapper().getOptions().getObjectFactory();
-            assertTrue(objectFactory.getClassNameCache().containsKey(Hotel.class.getName()));
-            assertTrue(objectFactory.getClassNameCache().containsKey(TravelAgency.class.getName()));
+            final DefaultClassInfoPersister classDiscriminator = (DefaultClassInfoPersister) getMorphia()
+                    .getMapper().getOptions().getClassInfoPersister();
+            assertTrue(classDiscriminator.getClassCache().containsKey(Hotel.class.getName()));
+            assertTrue(classDiscriminator.getClassCache().containsKey(TravelAgency.class.getName()));
         } finally {
             getMorphia().getMapper().getOptions().setCacheClassLookups(false);
         }
@@ -214,7 +218,8 @@ public class TestMapping extends TestBase {
         cea.res = new RenamedEmbedded[]{new RenamedEmbedded()};
 
         final DBObject dbObj = getMorphia().toDBObject(cea);
-        assertTrue(!((DBObject) ((List) dbObj.get("res")).get(0)).containsField(Mapper.CLASS_NAME_FIELDNAME));
+        assertTrue(!((DBObject) ((List) dbObj.get("res")).get(0))
+                .containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME));
     }
 
     @Test
@@ -243,7 +248,7 @@ public class TestMapping extends TestBase {
         cee.cil = new ContainsIntegerList();
         cee.cil.intList = Collections.singletonList(1);
         final DBObject dbObj = getMorphia().toDBObject(cee);
-        assertTrue(!((DBObject) dbObj.get("cil")).containsField(Mapper.CLASS_NAME_FIELDNAME));
+        assertTrue(!((DBObject) dbObj.get("cil")).containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME));
     }
 
     @Test
@@ -665,7 +670,8 @@ public class TestMapping extends TestBase {
         borg.setAddress(address);
 
         BasicDBObject hotelDbObj = (BasicDBObject) getMorphia().toDBObject(borg);
-        assertTrue(!(((DBObject) ((List) hotelDbObj.get("phoneNumbers")).get(0)).containsField(Mapper.CLASS_NAME_FIELDNAME)));
+        assertTrue(!(((DBObject) ((List) hotelDbObj.get("phoneNumbers")).get(0))
+                .containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME)));
 
 
         hotels.save(hotelDbObj);

--- a/morphia/src/test/java/org/mongodb/morphia/issue325/TestEmbeddedClassname.java
+++ b/morphia/src/test/java/org/mongodb/morphia/issue325/TestEmbeddedClassname.java
@@ -11,7 +11,7 @@ import org.mongodb.morphia.annotations.Entity;
 import org.mongodb.morphia.annotations.Id;
 import org.mongodb.morphia.annotations.PreLoad;
 import org.mongodb.morphia.annotations.Transient;
-import org.mongodb.morphia.mapping.Mapper;
+import org.mongodb.morphia.mapping.classinfo.DefaultClassInfoPersister;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,21 +32,21 @@ public class TestEmbeddedClassname extends TestBase {
         DBObject aRaw = r.singleA.raw;
 
         // Test that singleA does not contain the class name
-        Assert.assertFalse(aRaw.containsField(Mapper.CLASS_NAME_FIELDNAME));
+        Assert.assertFalse(aRaw.containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME));
 
         // Test that aList does not contain the class name
         aRaw = r.aList.get(0).raw;
-        Assert.assertFalse(aRaw.containsField(Mapper.CLASS_NAME_FIELDNAME));
+        Assert.assertFalse(aRaw.containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME));
 
         // Test that bList does not contain the class name of the subclass
         ds.update(ds.find(Root.class), ds.createUpdateOperations(Root.class).addToSet("bList", new B()));
         r = ds.get(Root.class, "id");
 
         aRaw = r.aList.get(0).raw;
-        Assert.assertFalse(aRaw.containsField(Mapper.CLASS_NAME_FIELDNAME));
+        Assert.assertFalse(aRaw.containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME));
 
         DBObject bRaw = r.bList.get(0).getRaw();
-        Assert.assertFalse(bRaw.containsField(Mapper.CLASS_NAME_FIELDNAME));
+        Assert.assertFalse(bRaw.containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME));
 
         ds.delete(ds.find(Root.class));
 
@@ -59,9 +59,9 @@ public class TestEmbeddedClassname extends TestBase {
 
         // test that singleA.raw *does* contain the classname because we stored a subclass there
         aRaw = r.singleA.raw;
-        Assert.assertTrue(aRaw.containsField(Mapper.CLASS_NAME_FIELDNAME));
+        Assert.assertTrue(aRaw.containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME));
         DBObject bRaw2 = r.aList.get(0).raw;
-        Assert.assertTrue(bRaw2.containsField(Mapper.CLASS_NAME_FIELDNAME));
+        Assert.assertTrue(bRaw2.containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME));
     }
 
     @Entity(noClassnameStored = true)

--- a/morphia/src/test/java/org/mongodb/morphia/mapping/MapImplTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/mapping/MapImplTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.mongodb.morphia.TestBase;
 import org.mongodb.morphia.annotations.Embedded;
 import org.mongodb.morphia.annotations.Id;
+import org.mongodb.morphia.mapping.classinfo.DefaultClassInfoPersister;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -35,7 +36,7 @@ public class MapImplTest extends TestBase {
                                                                           .findOne()
                                                                           .get("values")).get(
                                                                                                  "first");
-        final boolean hasF = goo.containsField(Mapper.CLASS_NAME_FIELDNAME);
+        final boolean hasF = goo.containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME);
         assertTrue(!hasF);
     }
 
@@ -55,7 +56,7 @@ public class MapImplTest extends TestBase {
                                                                           .findOne()
                                                                           .get("values")).get(
                                                                                                  "second");
-        final boolean hasF = goo.containsField(Mapper.CLASS_NAME_FIELDNAME);
+        final boolean hasF = goo.containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME);
         assertTrue("className should not be here.", !hasF);
     }
 
@@ -74,7 +75,7 @@ public class MapImplTest extends TestBase {
                                                                           .findOne()
                                                                           .get("values"))
                                                       .get("second");
-        final boolean hasF = goo.containsField(Mapper.CLASS_NAME_FIELDNAME);
+        final boolean hasF = goo.containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME);
         assertTrue("className should be here.", hasF);
     }
 
@@ -91,7 +92,7 @@ public class MapImplTest extends TestBase {
                                                                           .findOne()
                                                                           .get("values"))
                                                       .get("first");
-        final boolean hasF = goo.containsField(Mapper.CLASS_NAME_FIELDNAME);
+        final boolean hasF = goo.containsField(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME);
         assertTrue(hasF);
     }
 

--- a/morphia/src/test/java/org/mongodb/morphia/query/TestQuery.java
+++ b/morphia/src/test/java/org/mongodb/morphia/query/TestQuery.java
@@ -43,7 +43,7 @@ import org.mongodb.morphia.annotations.Indexed;
 import org.mongodb.morphia.annotations.PrePersist;
 import org.mongodb.morphia.annotations.Property;
 import org.mongodb.morphia.annotations.Reference;
-import org.mongodb.morphia.mapping.Mapper;
+import org.mongodb.morphia.mapping.classinfo.DefaultClassInfoPersister;
 import org.mongodb.morphia.testmodel.Hotel;
 import org.mongodb.morphia.testmodel.Rectangle;
 
@@ -1082,7 +1082,7 @@ public class TestQuery extends TestBase {
             .project("_id", true)
             .project("first_name", true)
             .getFieldsObject();
-        assertNull(fields.get(Mapper.CLASS_NAME_FIELDNAME));
+        assertNull(fields.get(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME));
     }
 
     @Test
@@ -1262,7 +1262,7 @@ public class TestQuery extends TestBase {
         DBObject fields = getDs()
             .find(ContainsRenamedFields.class)
             .retrievedFields(true, "_id", "first_name").getFieldsObject();
-        assertNull(fields.get(Mapper.CLASS_NAME_FIELDNAME));
+        assertNull(fields.get(DefaultClassInfoPersister.DEFAULT_DISCRIMINATOR_FIELD_NAME));
     }
 
     @Test


### PR DESCRIPTION
Hi! I'd like to propose adding two interfaces for a rudimentary polymorphic discriminator system to Morphia. 

### background

Morphia currently handles polymorphic deserialization by storing a fully qualified class name in a hardcoded `className` field. Although simple and predictable, this method imposes serious restrictions on clients of the objects. Repackaging a class requires jumping through hoops in production, and non-Java clients of the serialized data types are at a disadvantage. 

### similar solutions to the problem

Other Java serialization libraries like Jackson and JAXB provide for logical names as discriminator values, which provide greater flexibility via their indirection. See, for example, Jackson's `@JsonTypeInfo` [annotation ](http://fasterxml.github.io/jackson-annotations/javadoc/2.9/) with its `Use.NAME` enum name. 

### proposed code

In this pull request, I encapsulated the `className` field and its class loader logic with two interfaces -- a `ClassInfoPersister` and a `ClassIdMapper`. The `ClassInfoPersister` is tasked with, well, persisting class information; it provides methods for storing class information, removing class information, adding class information to a projection, and lastly, loading a `Class<T>` from data. The `ClassIdMapper` is a simpler interface to implement; it just goes from `String` class id to `Class<T>` and vice versa. 

### expected usage

Many type discriminator strategies will still use one fixed field -- `className` or `@type` -- for their class id; in this case, they need only implement `ClassIdMapper` and parameterize `DefaultClassInfoPersister`. On the other hand, if you want to implement a more complicated discriminator pattern -- e.g. dispatching off a preexisting enum field -- you'll likely need to implement the larger interface. I also provided a pretty common sense implementation of `ClassIdMapper` that is backed by a simple map (I'm going to use this one immediately in some other code).

With an eye towards more complicated future implementations, most of the `ClassInfoPersister` methods include a `Class<?>` for any known supertypes currently available (e.g. either the type of a `MappedField` or an entity), although the provided implementation ignores those values.

### backwards compatibility

The default implementation is completely backwards compatible. There are no changes to `public` or `protected` APIs; I did however take the liberty of deprecating three members:
- the public static constant `Mapper#CLASS_NAME_FIELDNAME`, which is now more properly owned by `DefaultClassInfoPersister`. 
- `public Map<String, Class> getClassNameCache` -- this seemed intended to expose state for testing but no longer directly owns the state with the above intervening interfaces
- a protected helper method for accessing a class loader that's no longer used internally; I doubt there are any clients out there, but who knows?

### from here

An obvious next step in Morphia's style would be to add an annotation that indicates the discriminator value. In its mapping process, Morphia could detect the alternate `Discriminator` anno, add the value and the annotated class to a hash map, and then pass it to the above configured `FixedMapClassIdMapper` -- letting clients annotate define their own logical names via annotations, just like other libraries.

Let me know what you think! I'd find this pretty useful. 