### PR TITLE
#1008 Support for sub queries in $lookup

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipeline.java
+++ b/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipeline.java
@@ -130,8 +130,20 @@ public interface AggregationPipeline {
      */
     AggregationPipeline lookup(String from, String localField, String foreignField, String as);
 
-    // TODO: I am unsure about the interface, especially with the let parameter type.
-    // TODO Documentation
+    /**
+     * Performs a left outer join to an unsharded collection in the same database to filter in documents from the “joined” collection for
+     * processing. To each input document, the $lookup stage adds a new array field whose elements are the matching documents from the
+     * “joined” collection. The $lookup stage passes these reshaped documents to the next stage.
+     *
+     * @param from     Specifies the collection in the same database to perform the join with. The from collection cannot be sharded.
+     * @param let      Optional. Specifies variables to use in the pipeline field stages. Use the variable expressions to access the
+     *                 fields from the documents input to the $lookup stage.
+     * @param pipeline Specifies the pipeline to run on the joined collection.
+     * @param as       Specifies the name of the new array field to add to the input documents.
+     * @return this
+     * @mongodb.driver.manual reference/operator/aggregation/lookup $lookup
+     * @since 1.4
+     */
     AggregationPipeline lookup(String from, BasicDBObject let, AggregationPipeline pipeline, String as);
 
     /**

--- a/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipeline.java
+++ b/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipeline.java
@@ -2,6 +2,7 @@ package org.mongodb.morphia.aggregation;
 
 
 import com.mongodb.AggregationOptions;
+import com.mongodb.BasicDBObject;
 import com.mongodb.ReadPreference;
 import org.mongodb.morphia.query.Query;
 import org.mongodb.morphia.query.Sort;
@@ -128,6 +129,10 @@ public interface AggregationPipeline {
      * @since 1.2
      */
     AggregationPipeline lookup(String from, String localField, String foreignField, String as);
+
+    // TODO: I am unsure about the interface, especially with the let parameter type.
+    // TODO Documentation
+    AggregationPipeline lookup(String from, BasicDBObject let, AggregationPipeline pipeline, String as);
 
     /**
      * Filters the document stream to allow only matching documents to pass unmodified into the next pipeline stage. $match uses standard

--- a/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipelineImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipelineImpl.java
@@ -156,6 +156,15 @@ public class AggregationPipelineImpl implements AggregationPipeline {
         return this;
     }
 
+    // TODO: I am unsure about the interface, especially with the let parameter type.
+    public AggregationPipeline lookup(final String from, final BasicDBObject let, final AggregationPipeline pipeline, final String as) {
+        stages.add(new BasicDBObject("$lookup", new BasicDBObject("from", from)
+            .append("let", let)
+            .append("pipeline", ((AggregationPipelineImpl) pipeline).getStages())
+            .append("as", as)));
+        return this;
+    }
+
     @Override
     public AggregationPipeline match(final Query query) {
         stages.add(new BasicDBObject("$match", query.getQueryObject()));

--- a/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipelineImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipelineImpl.java
@@ -156,12 +156,17 @@ public class AggregationPipelineImpl implements AggregationPipeline {
         return this;
     }
 
-    // TODO: I am unsure about the interface, especially with the let parameter type.
+    @Override
     public AggregationPipeline lookup(final String from, final BasicDBObject let, final AggregationPipeline pipeline, final String as) {
-        stages.add(new BasicDBObject("$lookup", new BasicDBObject("from", from)
-            .append("let", let)
+        BasicDBObject parameters = new BasicDBObject("from", from)
             .append("pipeline", ((AggregationPipelineImpl) pipeline).getStages())
-            .append("as", as)));
+            .append("as", as);
+
+        if(let != null) {
+            parameters.append("let", let);
+        }
+
+        stages.add(new BasicDBObject("$lookup", parameters));
         return this;
     }
 

--- a/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipelineImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/aggregation/AggregationPipelineImpl.java
@@ -162,7 +162,7 @@ public class AggregationPipelineImpl implements AggregationPipeline {
             .append("pipeline", ((AggregationPipelineImpl) pipeline).getStages())
             .append("as", as);
 
-        if(let != null) {
+        if (let != null) {
             parameters.append("let", let);
         }
 

--- a/morphia/src/test/java/org/mongodb/morphia/aggregation/AggregationTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/aggregation/AggregationTest.java
@@ -26,7 +26,6 @@ import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.CollationStrength;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.ValidationOptions;
-import com.sun.xml.internal.xsom.impl.scd.Iterators;
 
 import org.bson.Document;
 import org.bson.types.ObjectId;
@@ -345,14 +344,12 @@ public class AggregationTest extends TestBase {
         getDs().save(warehouses);
 
         BasicDBObject let = obj("order_item", "$item").append("order_qty", "$quantity");
-        BasicDBObject condition1 = obj("$eq", asList("$stock_item", "$$order_item"));
+        BasicDBObject condition1 = obj("$eq", asList("$stockItem", "$$order_item"));
         BasicDBObject condition2 = obj("$gte", asList("$instock", "$$order_qty"));
         AggregationPipeline innerPipeline = getDs().createAggregation(Warehouse.class)
             .match(getDs().getQueryFactory().createQuery(getDs())
                 .criteria("$expr").equal(obj("$and", asList(condition1, condition2)))
-                .getQuery())
-            //.project(projection("stock_item").suppress(), projection("_id").suppress())
-            ;
+                .getQuery());
 
         getDs().createAggregation(Order.class)
             .lookup("warehouses", let, innerPipeline, "stockdata")
@@ -853,7 +850,7 @@ public class AggregationTest extends TestBase {
     public static class Warehouse {
         @Id
         private int id;
-        private String stock_item;
+        private String stockItem;
         private String warehouse;
         private int instock;
 
@@ -865,25 +862,25 @@ public class AggregationTest extends TestBase {
             this.id = id;
         }
 
-        Warehouse(final int id, final String stock_item, final String warehouse) {
+        Warehouse(final int id, final String stockItem, final String warehouse) {
             this.id = id;
-            this.stock_item = stock_item;
+            this.stockItem = stockItem;
             this.warehouse = warehouse;
         }
 
-        Warehouse(final int id, final String stock_item, final String warehouse, final int instock) {
+        Warehouse(final int id, final String stockItem, final String warehouse, final int instock) {
             this.id = id;
-            this.stock_item = stock_item;
+            this.stockItem = stockItem;
             this.warehouse = warehouse;
             this.instock = instock;
         }
 
         public String getStockItem() {
-            return stock_item;
+            return stockItem;
         }
 
-        public void setDescription(final String stock_item) {
-            this.stock_item = stock_item;
+        public void setStockItem(final String stockItem) {
+            this.stockItem = stockItem;
         }
 
         public int getInstock() {
@@ -927,7 +924,7 @@ public class AggregationTest extends TestBase {
             if (instock != warehouse.instock) {
                 return false;
             }
-            if (stock_item != null ? !stock_item.equals(warehouse.stock_item) : warehouse.stock_item != null) {
+            if (stockItem != null ? !stockItem.equals(warehouse.stockItem) : warehouse.stockItem != null) {
                 return false;
             }
             return this.warehouse != null ? this.warehouse.equals(warehouse.warehouse) : warehouse.warehouse == null;
@@ -937,7 +934,7 @@ public class AggregationTest extends TestBase {
         @Override
         public int hashCode() {
             int result = id;
-            result = 31 * result + (stock_item != null ? stock_item.hashCode() : 0);
+            result = 31 * result + (stockItem != null ? stockItem.hashCode() : 0);
             result = 31 * result + (warehouse != null ? warehouse.hashCode() : 0);
             result = 31 * result + instock;
             return result;
@@ -945,12 +942,12 @@ public class AggregationTest extends TestBase {
 
         @Override
         public String toString() {
-            return "Warehouse{" +
-                "id=" + id +
-                ", stock_item='" + stock_item + '\'' +
-                ", warehouse='" + warehouse + '\'' +
-                ", instock=" + instock +
-                '}';
+            return "Warehouse{"
+                + "id=" + id
+                + ", stockItem='" + stockItem + '\''
+                + ", warehouse='" + warehouse + '\''
+                + ", instock=" + instock
+                + '}';
         }
     }
 }


### PR DESCRIPTION
This pull request aims to provide support for the new 3.6 sub-queries in the $lookup aggregation stage as documented in https://docs.mongodb.com/manual/reference/operator/aggregation/lookup/#join-conditions-and-uncorrelated-sub-queries. Test case is taken from the official documentation at: https://docs.mongodb.com/manual/reference/operator/aggregation/lookup/#join-conditions-and-uncorrelated-sub-queries

I was and still am really unsure about the interface because of the let parameter being just a BasicDBObject. It's usage came in quite handy for me, at least handier than a Map<String, String>. As I am not that deep into the depths of Morphia interfaces, I might have overlooked any similar interface where one would have to use a simple map. Happy to refactor that accordingly.