### PR TITLE
add field name to an exception

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/query/UpdateOpsImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/UpdateOpsImpl.java
@@ -217,7 +217,7 @@ public class UpdateOpsImpl<T> implements UpdateOperations<T> {
     @Override
     public UpdateOperations<T> set(final String field, final Object value) {
         if (value == null) {
-            throw new QueryException("Value cannot be null.");
+            throw new QueryException("Value for field [" + field + "] cannot be null.");
         }
 
         add(UpdateOperator.SET, field, value, true);


### PR DESCRIPTION
When a field is not set, i'd be nice to know what field it is - currently we are seeing just `Value cannot be null` and we start the scavenger hunt to find out what the field is. 
Would be good to show field names for ever missing (null) field