### PR TITLE
Retain order of Map in update flow

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
@@ -50,7 +50,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -937,7 +937,7 @@ public class Mapper {
                 if (isPropertyType(subType)) {
                     return toDBObject(newObj);
                 } else {
-                    final HashMap m = new HashMap();
+                    final LinkedHashMap m = new LinkedHashMap();
                     for (final Map.Entry e : (Iterable<Map.Entry>) ((Map) newObj).entrySet()) {
                         m.put(e.getKey(), toMongoObject(e.getValue(), includeClassName));
                     }


### PR DESCRIPTION
When calling DAO<T, U>.update(query, operation) and setting a LinkedHashMap in an attribute would result in ordering of that Map being lost due to the usage of HashMap.

I have replaced this usage with a LinkedHashMap and this fixes this issue. 