### PR TITLE
fix getByKeys()

### DIFF
--- a/morphia/src/main/java/dev/morphia/DatastoreImpl.java
+++ b/morphia/src/main/java/dev/morphia/DatastoreImpl.java
@@ -477,7 +477,8 @@ public class DatastoreImpl implements AdvancedDatastore {
             for (final Key key : kindKeys) {
                 objIds.add(key.getId());
             }
-            final List kindResults = find(entry.getKey(), null).disableValidation().filter("_id in", objIds).asList();
+            final Class clazzKind = clazz == null ? kindKeys.get(0).getType() : clazz;
+            final List kindResults = find(entry.getKey(), clazzKind).disableValidation().filter("_id in", objIds).asList();
             entities.addAll(kindResults);
         }
 

--- a/morphia/src/test/java/dev/morphia/TestDatastore.java
+++ b/morphia/src/test/java/dev/morphia/TestDatastore.java
@@ -744,6 +744,16 @@ public class TestDatastore extends TestBase {
         }
     }
 
+    @Entity(value = "facebook_users", noClassnameStored = true)
+    public static class FacebookUserWithNoClassNameStored extends FacebookUser {
+        public FacebookUserWithNoClassNameStored(long id, String name) {
+            super(id, name);
+        }
+
+        public FacebookUserWithNoClassNameStored() {
+        }
+    }
+
     @SuppressWarnings("UnusedDeclaration")
     public static class LifecycleListener {
         private static boolean prePersist;

--- a/morphia/src/test/java/dev/morphia/query/TestQuery.java
+++ b/morphia/src/test/java/dev/morphia/query/TestQuery.java
@@ -11,6 +11,8 @@ import com.mongodb.MongoInternalException;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.model.CollationStrength;
+import dev.morphia.TestDatastore;
+import dev.morphia.TestDatastore.FacebookUserWithNoClassNameStored;
 import org.bson.types.CodeWScope;
 import org.bson.types.ObjectId;
 import org.json.JSONException;
@@ -912,6 +914,48 @@ public class TestQuery extends TestBase {
         final FacebookUser fbUser2 = new FacebookUser(2, "tom");
         final FacebookUser fbUser3 = new FacebookUser(3, "oli");
         final FacebookUser fbUser4 = new FacebookUser(4, "frank");
+        final Iterable<Key<FacebookUser>> fbKeys = getDs().save(asList(fbUser1, fbUser2, fbUser3, fbUser4));
+        assertEquals(1, fbUser1.getId());
+
+        final List<Key<FacebookUser>> fbUserKeys = new ArrayList<Key<FacebookUser>>();
+        for (final Key<FacebookUser> key : fbKeys) {
+            fbUserKeys.add(key);
+        }
+
+        assertEquals(fbUser1.getId(), fbUserKeys.get(0).getId());
+        assertEquals(fbUser2.getId(), fbUserKeys.get(1).getId());
+        assertEquals(fbUser3.getId(), fbUserKeys.get(2).getId());
+        assertEquals(fbUser4.getId(), fbUserKeys.get(3).getId());
+
+        final KeysKeysKeys k1 = new KeysKeysKeys(null, fbUserKeys);
+        final Key<KeysKeysKeys> k1Key = getDs().save(k1);
+        assertEquals(k1.getId(), k1Key.getId());
+
+        final KeysKeysKeys k1Reloaded = getDs().get(k1);
+        final KeysKeysKeys k1Loaded = getDs().getByKey(KeysKeysKeys.class, k1Key);
+        assertNotNull(k1Reloaded);
+        assertNotNull(k1Loaded);
+        for (final Key<FacebookUser> key : k1Loaded.getUsers()) {
+            assertNotNull(key.getId());
+        }
+
+        assertEquals(4, k1Loaded.getUsers().size());
+
+        final List<FacebookUser> fbUsers = getDs().getByKeys(FacebookUser.class, k1Loaded.getUsers());
+        assertEquals(4, fbUsers.size());
+        for (final FacebookUser fbUser : fbUsers) {
+            assertNotNull(fbUser);
+            assertNotNull(fbUser.getId());
+            assertNotNull(fbUser.getUsername());
+        }
+    }
+
+    @Test
+    public void testKeyListLookupsWithNoClassNameStored() {
+        final FacebookUser fbUser1 = new FacebookUserWithNoClassNameStored(1, "scott");
+        final FacebookUser fbUser2 = new FacebookUserWithNoClassNameStored(2, "tom");
+        final FacebookUser fbUser3 = new FacebookUserWithNoClassNameStored(3, "oli");
+        final FacebookUser fbUser4 = new FacebookUserWithNoClassNameStored(4, "frank");
         final Iterable<Key<FacebookUser>> fbKeys = getDs().save(asList(fbUser1, fbUser2, fbUser3, fbUser4));
         assertEquals(1, fbUser1.getId());
 


### PR DESCRIPTION
DatastoreImpl call find(String,Class) with null will cause an exception:
java.lang.NullPointerException: null
	at java.lang.Class.isAssignableFrom(Native Method)
	at org.mongodb.morphia.mapping.DefaultCreator.createInstance(DefaultCreator.java:74)
	at org.mongodb.morphia.mapping.DefaultCreator.createInstance(DefaultCreator.java:91)
	at org.mongodb.morphia.mapping.Mapper.fromDBObject(Mapper.java:192)
	at org.mongodb.morphia.query.MorphiaIterator.convertItem(MorphiaIterator.java:134)
	at org.mongodb.morphia.query.MorphiaIterator.processItem(MorphiaIterator.java:146)
	at org.mongodb.morphia.query.MorphiaIterator.next(MorphiaIterator.java:117)
	at org.mongodb.morphia.query.QueryImpl.asList(QueryImpl.java:147)
	at org.mongodb.morphia.query.QueryImpl.asList(QueryImpl.java:139)
	at org.mongodb.morphia.DatastoreImpl.getByKeys(DatastoreImpl.java:479)