### PR TITLE
Fixes issue: https://github.com/MorphiaOrg/morphia/issues/1363

### DIFF
--- a/morphia/src/main/java/dev/morphia/mapping/MappedField.java
+++ b/morphia/src/main/java/dev/morphia/mapping/MappedField.java
@@ -36,6 +36,7 @@ import dev.morphia.annotations.Transient;
 import dev.morphia.annotations.Version;
 import dev.morphia.mapping.experimental.MorphiaReference;
 import dev.morphia.utils.ReflectionUtils;
+import sun.reflect.generics.reflectiveObjects.TypeVariableImpl;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
@@ -651,6 +652,8 @@ public class MappedField {
             return (Class) ((ParameterizedType) t).getRawType();
         } else if (t instanceof WildcardType) {
             return (Class) ((WildcardType) t).getUpperBounds()[0];
+        } else if (t instanceof TypeVariableImpl) {
+            return (Class) ((TypeVariableImpl) t).getBounds()[0];
         }
 
         throw new RuntimeException("Generic TypeVariable not supported!");


### PR DESCRIPTION
Issue link: #https://github.com/MorphiaOrg/morphia/issues/1363

**What this PR does:**
By adding an additional condition in MappedField.java,  I am able to save an entity in MongoDB with an instance variable like:

` Set<Employee<O>> orderDetails:`

Sample entity class:
```

@Entity
class Employee<O extends IOrder> {
.
.
@org.mongodb.morphia.annotations.Embedded
private Employee<O> employeeOrder; // Able to save with existing 1.5.3 Morphia jar
.
.
@org.mongodb.morphia.annotations.Embedded
private Set<Employee<O>> orderDetails = Sets.newHashSet(); // Not able to save with existing 1.5.3 Morphia jar but, it works after my changes
}

```
**Version information:**
Server Version: 3.0.15
Driver Version: 3.8.2
Morphia Version: 1.5.3
JDK: 1.8