### PR TITLE
new config format, and use sonatype API to fetch SNAPSHOT javadoc jar.

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -19,5 +19,5 @@ extensions-config:
   - path: '@djencks/antora-javadoc'
     config:
       sources:
-        - url: ./dev.javadoc.jar
+        - url: https://oss.sonatype.org/service/local/artifact/maven/content?r=snapshots&g=dev.morphia.morphia&a=morphia-core&v=2.2.0-SNAPSHOT&c=javadoc
           module: javadoc

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -15,7 +15,9 @@ asciidoc:
     docsRef: http://docs.mongodb.org/manual
     srcRef: https://github.com/MorphiaOrg/morphia/blob/master
 
-javadoc:
-  sources:
-    - url: ./dev.javadoc.jar
-      module: javadoc
+extensions-config:
+  - path: '@djencks/antora-javadoc'
+    config:
+      sources:
+        - url: ./dev.javadoc.jar
+          module: javadoc


### PR DESCRIPTION
This shows the new @djencks/antora-javadoc config format and also how to use the sonatype REST api to fetch the latest SNAPSHOT javadoc jar. If you want to keep the configuration in the descriptors rather than the playbook, I think it would be easier to just modify the config yourself than deal with a PR per branch.  If you'd rather have PRs let me know. 