### PR TITLE
Fixed referencing (and removed embedding) entities 

### DIFF
--- a/core/src/main/java/dev/morphia/mapping/MorphiaDefaultsConvention.java
+++ b/core/src/main/java/dev/morphia/mapping/MorphiaDefaultsConvention.java
@@ -1,28 +1,19 @@
 package dev.morphia.mapping;
 
-import dev.morphia.Datastore;
-import dev.morphia.annotations.AlsoLoad;
-import dev.morphia.annotations.Embedded;
-import dev.morphia.annotations.Entity;
-import dev.morphia.annotations.Handler;
-import dev.morphia.annotations.Property;
-import dev.morphia.annotations.Transient;
-import dev.morphia.annotations.experimental.IdField;
-import dev.morphia.mapping.codec.ArrayFieldAccessor;
-import dev.morphia.mapping.codec.FieldAccessor;
-import dev.morphia.mapping.codec.MorphiaPropertySerialization;
-import dev.morphia.mapping.codec.pojo.EntityModelBuilder;
-import dev.morphia.mapping.codec.pojo.FieldModelBuilder;
-import dev.morphia.mapping.codec.pojo.TypeData;
-import org.bson.codecs.pojo.PropertyAccessor;
+import static java.lang.reflect.Modifier.*;
 
-import java.lang.annotation.Annotation;
+import java.lang.annotation.*;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.Iterator;
+import java.lang.reflect.*;
+import java.util.*;
 
-import static java.lang.reflect.Modifier.isAbstract;
-import static java.lang.reflect.Modifier.isStatic;
+import dev.morphia.*;
+import dev.morphia.annotations.*;
+import dev.morphia.annotations.experimental.*;
+import dev.morphia.mapping.codec.*;
+import dev.morphia.mapping.codec.pojo.TypeData;
+import dev.morphia.mapping.codec.pojo.*;
+import org.bson.codecs.pojo.*;
 
 /**
  * A set of conventions to apply to Morphia entities
@@ -149,6 +140,9 @@ public class MorphiaDefaultsConvention implements MorphiaConvention {
             if (handler == null) {
                 for (Annotation annotation : builder.annotations()) {
                     handler = annotation.annotationType().getAnnotation(Handler.class);
+                    if (handler != null) {
+                        break;
+                    }
                 }
             }
         }

--- a/core/src/main/java/dev/morphia/mapping/MorphiaDefaultsConvention.java
+++ b/core/src/main/java/dev/morphia/mapping/MorphiaDefaultsConvention.java
@@ -1,20 +1,28 @@
 package dev.morphia.mapping;
 
-import static java.lang.reflect.Modifier.*;
-
-import java.lang.annotation.*;
-import java.lang.reflect.Field;
-import java.lang.reflect.*;
-import java.util.*;
-
-import dev.morphia.*;
-import dev.morphia.annotations.*;
-import dev.morphia.annotations.experimental.*;
-import dev.morphia.mapping.codec.*;
+import dev.morphia.Datastore;
+import dev.morphia.annotations.AlsoLoad;
+import dev.morphia.annotations.Embedded;
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Handler;
+import dev.morphia.annotations.Property;
+import dev.morphia.annotations.Transient;
+import dev.morphia.annotations.experimental.IdField;
+import dev.morphia.mapping.codec.ArrayFieldAccessor;
+import dev.morphia.mapping.codec.FieldAccessor;
+import dev.morphia.mapping.codec.MorphiaPropertySerialization;
+import dev.morphia.mapping.codec.pojo.EntityModelBuilder;
+import dev.morphia.mapping.codec.pojo.FieldModelBuilder;
 import dev.morphia.mapping.codec.pojo.TypeData;
-import dev.morphia.mapping.codec.pojo.*;
-import org.bson.codecs.pojo.*;
+import org.bson.codecs.pojo.PropertyAccessor;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Iterator;
+
+import static java.lang.reflect.Modifier.isAbstract;
+import static java.lang.reflect.Modifier.isStatic;
 /**
  * A set of conventions to apply to Morphia entities
  */

--- a/core/src/main/java/dev/morphia/mapping/MorphiaDefaultsConvention.java
+++ b/core/src/main/java/dev/morphia/mapping/MorphiaDefaultsConvention.java
@@ -146,11 +146,9 @@ public class MorphiaDefaultsConvention implements MorphiaConvention {
                                     .stream().filter(a -> a.getClass().equals(Handler.class))
                                     .findFirst().orElse(null);
             if (handler == null) {
-                for (Annotation annotation : builder.annotations()) {
-                    handler = annotation.annotationType().getAnnotation(Handler.class);
-                    if (handler != null) {
-                        break;
-                    }
+                Iterator<Annotation> iterator = builder.annotations().iterator();
+                while (handler == null && iterator.hasNext()) {
+                    handler = iterator.next().annotationType().getAnnotation(Handler.class);
                 }
             }
         }

--- a/core/src/test/java/dev/morphia/test/mapping/TestReferenceAnnotationPosition.java
+++ b/core/src/test/java/dev/morphia/test/mapping/TestReferenceAnnotationPosition.java
@@ -1,31 +1,25 @@
 package dev.morphia.test.mapping;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
-import static org.junit.Assert.*;
+import com.mongodb.client.MongoCollection;
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import dev.morphia.annotations.Reference;
+import dev.morphia.test.TestBase;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import org.bson.Document;
+import org.testng.annotations.Test;
 
-import java.lang.annotation.*;
-import java.util.*;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 
-import com.mongodb.client.*;
-import dev.morphia.annotations.*;
-import dev.morphia.test.*;
-import org.bson.*;
-import org.testng.annotations.*;
-
-@Target({FIELD})
-@Retention(RUNTIME)
-@interface AnAnnotation {
-
-}
+import static org.testng.Assert.assertEquals;
 
 public class TestReferenceAnnotationPosition extends TestBase {
-
-	@BeforeMethod
-	public void setUp() {
-		getDs().getMapper().getCollection(Box.class).deleteMany(new Document());
-		getDs().getMapper().getCollection(Item.class).deleteMany(new Document());
-	}
 
 	@Test
 	public void testReferenceAnnotationShouldNeverEmbedDocuments() {
@@ -47,7 +41,7 @@ public class TestReferenceAnnotationPosition extends TestBase {
 		Object items = firstDoc.get("items");
 		Object moreItems = firstDoc.get("moreItems");
 
-		assertEquals("Items should be stored as the same documents", items, moreItems);
+		assertEquals(items, moreItems, "Items should be stored as the same documents");
 	}
 
 }
@@ -133,4 +127,11 @@ class Item {
 	public int hashCode() {
 		return Objects.hash(id);
 	}
+}
+
+//this is a random annotation which doesn't play any role beside separating @Reference and field
+@Target({FIELD})
+@Retention(RUNTIME)
+@interface AnAnnotation {
+
 }

--- a/core/src/test/java/dev/morphia/test/mapping/TestReferenceAnnotationPosition.java
+++ b/core/src/test/java/dev/morphia/test/mapping/TestReferenceAnnotationPosition.java
@@ -1,0 +1,136 @@
+package dev.morphia.test.mapping;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+import static org.junit.Assert.*;
+
+import java.lang.annotation.*;
+import java.util.*;
+
+import com.mongodb.client.*;
+import dev.morphia.annotations.*;
+import dev.morphia.test.*;
+import org.bson.*;
+import org.testng.annotations.*;
+
+@Target({FIELD})
+@Retention(RUNTIME)
+@interface AnAnnotation {
+
+}
+
+public class TestReferenceAnnotationPosition extends TestBase {
+
+	@BeforeMethod
+	public void setUp() {
+		getDs().getMapper().getCollection(Box.class).deleteMany(new Document());
+		getDs().getMapper().getCollection(Item.class).deleteMany(new Document());
+	}
+
+	@Test
+	public void testReferenceAnnotationShouldNeverEmbedDocuments() {
+		getDs().getMapper().map(Box.class, Item.class);
+
+		Item item1 = new Item("item one");
+		Item item2 = new Item("item two");
+		Box box = new Box();
+		box.setItems(Set.of(item1, item2));
+		box.setMoreItems(Set.of(item1, item2));
+		getDs().save(List.of(item1, item2));
+		getDs().save(box);
+
+		MongoCollection<Document> collection = getMapper()
+			.getCollection(Box.class)
+			.withDocumentClass(Document.class);
+
+		Document firstDoc = collection.find().first();
+		Object items = firstDoc.get("items");
+		Object moreItems = firstDoc.get("moreItems");
+
+		assertEquals("Items should be stored as the same documents", items, moreItems);
+	}
+
+}
+
+@Entity
+class Box {
+	@Id
+	private UUID id = UUID.randomUUID();
+	@Reference
+	@AnAnnotation
+	private Set<Item> items;
+
+	@AnAnnotation
+	@Reference
+	private Set<Item> moreItems;
+
+	Box() {
+	}
+
+	public UUID getId() {
+		return id;
+	}
+
+	public void setId(UUID id) {
+		this.id = id;
+	}
+
+	public Set<Item> getItems() {
+		return items;
+	}
+
+	public void setItems(Set<Item> items) {
+		this.items = items;
+	}
+
+	public Set<Item> getMoreItems() {
+		return moreItems;
+	}
+
+	public void setMoreItems(Set<Item> moreItems) {
+		this.moreItems = moreItems;
+	}
+}
+
+@Entity
+class Item {
+	@Id
+	private UUID id = UUID.randomUUID();
+	private String name;
+
+	Item() {
+	}
+
+	public Item(String name) {
+		this.name = name;
+	}
+
+	public UUID getId() {
+		return id;
+	}
+
+	public void setId(UUID id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Item item = (Item) o;
+		return id.equals(item.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
+	}
+}


### PR DESCRIPTION
Fixed referencing (and removed embedding) entities if the `@Reference` annotation is not last over a field.
Frankly speaking I'm not entirely sure if this is the best fix, because it will break backward compatibility for souls who saved documents with `@Reference`d entities when the `@Reference` annotation wasn't the very last on a field.
However, it will be a saver for poor souls who (just like me) in their codebase use `@Reference`s mixed with other annotations and Morphia 1 and try to migrate.
I've mentioned that in #1549.
However, if this is a valid fix, I'd ask to backport it.

Thanks!