### PR TITLE
Fixing the ISO Date tests so they run from CET. 

### DIFF
--- a/core/src/test/java/dev/morphia/test/aggregation/experimental/TestDateExpression.java
+++ b/core/src/test/java/dev/morphia/test/aggregation/experimental/TestDateExpression.java
@@ -189,16 +189,14 @@ public class TestDateExpression extends ExpressionsTestBase {
 
     @Test
     public void testIsoDayOfWeek() throws ParseException {
-        assertAndCheckDocShape("{}", isoDayOfWeek(value(new SimpleDateFormat("MMM dd, yyyy").parse("August 14, 2011")))
-                                         .timezone(value("America/Chicago")), 6);
-        assertAndCheckDocShape("{}", isoDayOfWeek(value(new SimpleDateFormat("yyyy-MM-dd").parse("2016-01-01"))), 5);
+        assertAndCheckDocShape("{}", isoDayOfWeek(value(new SimpleDateFormat("MMM dd, yyyy zzz").parse("August 14, 2011 UTC"))), 7);
+        assertAndCheckDocShape("{}", isoDayOfWeek(value(new SimpleDateFormat("yyyy-MM-dd zzz").parse("2016-01-01 UTC"))), 5);
     }
 
     @Test
     public void testIsoWeek() throws ParseException {
-        assertAndCheckDocShape("{}", isoWeek(value(new SimpleDateFormat("MMM dd, yyyy").parse("August 14, 2011")))
-                           .timezone(value("America/Chicago")), 32);
-        assertAndCheckDocShape("{}", isoWeek(value(new SimpleDateFormat("MMM dd, yyyy").parse("Jan 4, 2016"))), 1);
+        assertAndCheckDocShape("{}", isoWeek(value(new SimpleDateFormat("MMM dd, yyyy zzz").parse("August 14, 2011 UTC"))), 32);
+        assertAndCheckDocShape("{}", isoWeek(value(new SimpleDateFormat("MMM dd, yyyy zzz").parse("Jan 4, 2016 UTC"))), 1);
     }
 
     @Test


### PR DESCRIPTION
Added a UTC timezone, which seems to fix the failing tests, but I also had to change the expected value of the day-of-week for August 14 since this is actually a Sunday, and the days are indexed from 1/Monday.

I'll be honest I'm not 100% sure I'm fixing the tests as intended! But these date tests never seem to run correctly from a European timezone and it means the build always fails.