### PR TITLE
Fixed variable typo in transactions.adoc

### DIFF
--- a/docs/modules/ROOT/pages/transactions.adoc
+++ b/docs/modules/ROOT/pages/transactions.adoc
@@ -33,7 +33,7 @@ Of course, it's not always possible to wrap things up neatly inside a lambda so 
 ----
 MorphiaSession session = datastore.startSession();
 session.startTransaction();
-User account = new User("jimbo", "jimhalpert@dundermifflin.com");
+User user = new User("jimbo", "jimhalpert@dundermifflin.com");
 user.setHomeAddress(new Address("123 Paper Lane", "Scranton", "PA", "18510"));
 session.save(user);
 session.commitTransaction();
@@ -47,7 +47,7 @@ This is essentially the same logic as above but now we're manually managing the 
 ----
 try(MorphiaSession session = datastore.startSession()) {
     session.startTransaction();
-    User account = new User("jimbo", "jimhalpert@dundermifflin.com");
+    User user = new User("jimbo", "jimhalpert@dundermifflin.com");
     user.setHomeAddress(new Address("123 Paper Lane", "Scranton", "PA", "18510"));
     session.save(user);
     session.commitTransaction();


### PR DESCRIPTION
Fixed variable typo.
Based on the context, the variable `account` might be `user`.