### PR TITLE
1599 - make DocumentReader able to handle Binary

### DIFF
--- a/core/src/main/java/dev/morphia/mapping/codec/reader/DocumentReader.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/reader/DocumentReader.java
@@ -77,18 +77,31 @@ public class DocumentReader implements BsonReader {
             Object binary = stage().value();
             if (binary instanceof UUID) {
                 return (byte) ((UUID) binary).version();
+            } else if (binary instanceof Binary) {
+                return ((Binary) binary).getType();
             } else {
                 return ((BsonBinary) binary).getType();
             }
         } finally {
             mark.reset();
         }
-
     }
 
     @Override
     public int peekBinarySize() {
-        return stage().<BsonBinary>value().getData().length;
+        BsonReaderMark mark = getMark();
+        try {
+            Object value = stage().value();
+            if (value instanceof UUID) {
+                return 16;
+            } else if (value instanceof Binary) {
+                return ((Binary) value).getData().length;
+            } else {
+                return ((BsonBinary) value).getData().length;
+            }
+        } finally {
+            mark.reset();
+        }
     }
 
     @Override


### PR DESCRIPTION
- `peekBinarySize` should not change state of the reader similar to `peekBinarySubType`
- `readBinaryData`, `peekBinarySubType`,`peekBinarySize` should support same set of types - `UUID`, `Binary`, `BsonBinary`