### PR TITLE
Instantiate classes with no empty constructor

### DIFF
--- a/core/src/main/java/dev/morphia/mapping/InstanceCreatorFactoryImpl.java
+++ b/core/src/main/java/dev/morphia/mapping/InstanceCreatorFactoryImpl.java
@@ -3,6 +3,7 @@ package dev.morphia.mapping;
 import dev.morphia.mapping.codec.MorphiaInstanceCreator;
 import dev.morphia.mapping.codec.pojo.EntityModel;
 import dev.morphia.mapping.experimental.ConstructorCreator;
+import dev.morphia.mapping.experimental.UnsafeConstructorCreator;
 import dev.morphia.sofia.Sofia;
 
 import java.lang.reflect.Constructor;
@@ -34,10 +35,15 @@ public class InstanceCreatorFactoryImpl implements InstanceCreatorFactory {
                         return new NoArgCreator(constructor);
                     };
                 } catch (NoSuchMethodException e) {
-                    Constructor<?> constructor = ConstructorCreator.getFullConstructor(model);
-                    creator = () -> {
-                        return new ConstructorCreator(model, constructor);
-                    };
+                    try {
+                        Constructor<?> constructor = ConstructorCreator.getFullConstructor(model);
+                        creator = () -> {
+                            return new ConstructorCreator(model, constructor);
+                        };
+                    } catch (IllegalStateException e1) {
+                        MorphiaInstanceCreator unsafeConstructorCreator = new UnsafeConstructorCreator(model);
+                        creator = () -> unsafeConstructorCreator;
+                    }
                 }
             } else {
                 throw new MappingException(Sofia.noSuitableConstructor(model.getType().getName()));

--- a/core/src/main/java/dev/morphia/mapping/experimental/ConstructorCreator.java
+++ b/core/src/main/java/dev/morphia/mapping/experimental/ConstructorCreator.java
@@ -69,7 +69,7 @@ public class ConstructorCreator implements MorphiaInstanceCreator {
                 return constructor;
             }
         }
-        throw new MappingException(Sofia.noSuitableConstructor(model.getType().getName()));
+        throw new IllegalStateException("No suitable constructor");
     }
 
     /**

--- a/core/src/main/java/dev/morphia/mapping/experimental/UnsafeAllocator.java
+++ b/core/src/main/java/dev/morphia/mapping/experimental/UnsafeAllocator.java
@@ -28,6 +28,9 @@ import java.lang.reflect.Modifier;
  * @author Joel Leitch
  * @author Jesse Wilson
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+        value = "REC_CATCH_EXCEPTION",
+        justification = "Unsafe")
 public abstract class UnsafeAllocator {
     public abstract <T> T newInstance(Class<T> c) throws Exception;
 

--- a/core/src/main/java/dev/morphia/mapping/experimental/UnsafeAllocator.java
+++ b/core/src/main/java/dev/morphia/mapping/experimental/UnsafeAllocator.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.morphia.mapping.experimental;
+
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/**
+ * Do sneaky things to allocate objects without invoking their constructors.
+ *
+ * @author Joel Leitch
+ * @author Jesse Wilson
+ */
+public abstract class UnsafeAllocator {
+    public abstract <T> T newInstance(Class<T> c) throws Exception;
+
+    public static UnsafeAllocator create() {
+        // try JVM
+        // public class Unsafe {
+        //   public Object allocateInstance(Class<?> type);
+        // }
+        try {
+            Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+            Field f = unsafeClass.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            final Object unsafe = f.get(null);
+            final Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
+            return new UnsafeAllocator() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public <T> T newInstance(Class<T> c) throws Exception {
+                    assertInstantiable(c);
+                    return (T) allocateInstance.invoke(unsafe, c);
+                }
+            };
+        } catch (Exception ignored) {
+        }
+
+        // try dalvikvm, post-gingerbread
+        // public class ObjectStreamClass {
+        //   private static native int getConstructorId(Class<?> c);
+        //   private static native Object newInstance(Class<?> instantiationClass, int methodId);
+        // }
+        try {
+            Method getConstructorId = ObjectStreamClass.class
+                    .getDeclaredMethod("getConstructorId", Class.class);
+            getConstructorId.setAccessible(true);
+            final int constructorId = (Integer) getConstructorId.invoke(null, Object.class);
+            final Method newInstance = ObjectStreamClass.class
+                    .getDeclaredMethod("newInstance", Class.class, int.class);
+            newInstance.setAccessible(true);
+            return new UnsafeAllocator() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public <T> T newInstance(Class<T> c) throws Exception {
+                    assertInstantiable(c);
+                    return (T) newInstance.invoke(null, c, constructorId);
+                }
+            };
+        } catch (Exception ignored) {
+        }
+
+        // try dalvikvm, pre-gingerbread
+        // public class ObjectInputStream {
+        //   private static native Object newInstance(
+        //     Class<?> instantiationClass, Class<?> constructorClass);
+        // }
+        try {
+            final Method newInstance = ObjectInputStream.class
+                    .getDeclaredMethod("newInstance", Class.class, Class.class);
+            newInstance.setAccessible(true);
+            return new UnsafeAllocator() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public <T> T newInstance(Class<T> c) throws Exception {
+                    assertInstantiable(c);
+                    return (T) newInstance.invoke(null, c, Object.class);
+                }
+            };
+        } catch (Exception ignored) {
+        }
+
+        // give up
+        return new UnsafeAllocator() {
+            @Override
+            public <T> T newInstance(Class<T> c) {
+                throw new UnsupportedOperationException("Cannot allocate " + c);
+            }
+        };
+    }
+
+    /**
+     * Check if the class can be instantiated by unsafe allocator. If the instance has interface or abstract modifiers
+     * throw an {@link java.lang.UnsupportedOperationException}
+     *
+     * @param c instance of the class to be checked
+     */
+    static void assertInstantiable(Class<?> c) {
+        int modifiers = c.getModifiers();
+        if (Modifier.isInterface(modifiers)) {
+            throw new UnsupportedOperationException("Interface can't be instantiated! Interface name: " + c.getName());
+        }
+        if (Modifier.isAbstract(modifiers)) {
+            throw new UnsupportedOperationException("Abstract class can't be instantiated! Class name: " + c.getName());
+        }
+    }
+}

--- a/core/src/main/java/dev/morphia/mapping/experimental/UnsafeConstructorCreator.java
+++ b/core/src/main/java/dev/morphia/mapping/experimental/UnsafeConstructorCreator.java
@@ -1,0 +1,30 @@
+package dev.morphia.mapping.experimental;
+
+import dev.morphia.mapping.MappingException;
+import dev.morphia.mapping.codec.MorphiaInstanceCreator;
+import dev.morphia.mapping.codec.pojo.EntityModel;
+import dev.morphia.mapping.codec.pojo.PropertyModel;
+import dev.morphia.sofia.Sofia;
+
+public class UnsafeConstructorCreator implements MorphiaInstanceCreator {
+    private static final UnsafeAllocator UNSAFE_ALLOCATOR = UnsafeAllocator.create();
+    private final Object instance;
+
+    public UnsafeConstructorCreator(EntityModel model) {
+        try {
+            instance = UNSAFE_ALLOCATOR.newInstance(model.getType());
+        } catch (Exception e) {
+            throw new MappingException(Sofia.noSuitableConstructor(model.getType().getName()));
+        }
+    }
+
+    @Override
+    public Object getInstance() {
+        return instance;
+    }
+
+    @Override
+    public void set(Object value, PropertyModel model) {
+        model.getAccessor().set(instance, value);
+    }
+}

--- a/core/src/test/java/dev/morphia/test/mapping/experimental/InstaceCreationTest.java
+++ b/core/src/test/java/dev/morphia/test/mapping/experimental/InstaceCreationTest.java
@@ -1,0 +1,66 @@
+package dev.morphia.test.mapping.experimental;
+
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import dev.morphia.query.FindOptions;
+import dev.morphia.test.TestBase;
+import org.bson.types.ObjectId;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class InstaceCreationTest extends TestBase {
+    @Test
+    public void basicReference() {
+        final Author author = new Author("Jane Austen");
+        getDs().save(author);
+
+        final Author loaded = getDs().find(Author.class).iterator(new FindOptions()
+                .limit(1)).tryNext();
+        assertEquals(author, loaded);
+    }
+
+    private static class BaseEntity {
+        @Id
+        protected ObjectId id;
+
+        public ObjectId getId() {
+            return id;
+        }
+    }
+
+    @Entity
+    private static class Author extends BaseEntity {
+
+        public Author(String name) {
+            this.name = name;
+        }
+
+        private String name;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final Author author = (Author) o;
+
+            if (id != null ? !id.equals(author.id) : author.id != null) {
+                return false;
+            }
+            return name != null ? name.equals(author.name) : author.name == null;
+        }
+
+        @Override
+        public String toString() {
+            return "Author{" +
+                    "id=" + id +
+                    ", name='" + name + '\'' +
+                    '}';
+        }
+    }
+}


### PR DESCRIPTION
Use unsafe allocator as a last resort for instantiating classes with no empty constructor

Solves:
https://github.com/MorphiaOrg/morphia/issues/1627
https://github.com/MorphiaOrg/morphia/issues/1448