### PR TITLE
Enum collection and map codecs

### DIFF
--- a/core/src/main/java/dev/morphia/mapping/codec/CollectionCodec.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/CollectionCodec.java
@@ -2,6 +2,7 @@ package dev.morphia.mapping.codec;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 
 import org.bson.BsonReader;
@@ -66,6 +67,7 @@ public class CollectionCodec<T> implements Codec<Collection<T>> {
         return encoderClass;
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     protected Collection<T> getInstance() {
         if (encoderClass.isInterface()) {
             if (encoderClass.isAssignableFrom(ArrayList.class)) {
@@ -75,6 +77,8 @@ public class CollectionCodec<T> implements Codec<Collection<T>> {
             } else {
                 throw new CodecConfigurationException(format("Unsupported Collection interface of %s!", encoderClass.getName()));
             }
+        } else if (encoderClass.equals(EnumSet.class)) {
+            return EnumSet.noneOf(((EnumCodec) codec).getEncoderClass());
         }
 
         try {

--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapPropertyCodecProvider.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapPropertyCodecProvider.java
@@ -1,6 +1,7 @@
 package dev.morphia.mapping.codec;
 
 import java.lang.reflect.Constructor;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,9 +96,12 @@ class MorphiaMapPropertyCodecProvider extends MorphiaPropertyCodecProvider {
             return encoderClass;
         }
 
+        @SuppressWarnings("rawtypes")
         private Map<K, V> getInstance() {
             if (encoderClass.isInterface()) {
                 return new HashMap<>();
+            } else if (encoderClass.equals(EnumMap.class)) {
+                return new EnumMap(keyType);
             }
             try {
                 final Constructor<Map<K, V>> constructor = encoderClass.getDeclaredConstructor();


### PR DESCRIPTION
enum map and enum set are very efficient in storage and performance in java. they don't have a regular constructor, so a special handling is needed to instantiate them 