### PR TITLE
change property codec registries from service loader to mapper

### DIFF
--- a/core/src/main/java/dev/morphia/DatastoreImpl.java
+++ b/core/src/main/java/dev/morphia/DatastoreImpl.java
@@ -111,7 +111,7 @@ public class DatastoreImpl implements AdvancedDatastore {
             importModels();
         }
 
-        morphiaCodecProviders.add(new MorphiaCodecProvider(this));
+        morphiaCodecProviders.add(new MorphiaCodecProvider(this, mapper.getOptions().propertyCodecProvider()));
 
         CodecRegistry codecRegistry = database.getCodecRegistry();
         List<CodecProvider> providers = new ArrayList<>();

--- a/core/src/main/java/dev/morphia/mapping/MapperOptions.java
+++ b/core/src/main/java/dev/morphia/mapping/MapperOptions.java
@@ -25,6 +25,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.bson.UuidRepresentation;
 import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.pojo.PropertyCodecProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +57,7 @@ public class MapperOptions {
     private final boolean enablePolymorphicQueries;
     private final ClassLoader classLoader;
     private final CodecProvider codecProvider;
+    private final PropertyCodecProvider propertyCodecProvider;
 
     private MapperOptions(Builder builder) {
         autoImportModels = builder.autoImportModels;
@@ -67,6 +69,7 @@ public class MapperOptions {
         }
 
         codecProvider = builder.codecProvider;
+        propertyCodecProvider = builder.propertyCodecProvider;
         collectionNaming = builder.collectionNaming;
         conventions = builder.conventions();
         dateStorage = builder.dateStorage();
@@ -133,6 +136,17 @@ public class MapperOptions {
     @MorphiaInternal
     public CodecProvider codecProvider() {
         return codecProvider;
+    }
+
+    /**
+     * @return the configured CodecProvider
+     * @see CodecProvider
+     * @since 2.3
+     */
+    @Nullable
+    @MorphiaInternal
+    public PropertyCodecProvider propertyCodecProvider() {
+        return propertyCodecProvider;
     }
 
     /**
@@ -281,6 +295,7 @@ public class MapperOptions {
         private boolean enablePolymorphicQueries;
         private ClassLoader classLoader;
         private CodecProvider codecProvider;
+        private PropertyCodecProvider propertyCodecProvider;
         private DateStorage dateStorage = DateStorage.UTC;
         private String discriminatorKey = "_t";
         private DiscriminatorFunction discriminator = DiscriminatorFunction.simpleName();
@@ -299,6 +314,7 @@ public class MapperOptions {
             cacheClassLookups = original.cacheClassLookups;
             classLoader = original.getClassLoader();
             codecProvider = original.codecProvider;
+            propertyCodecProvider = original.propertyCodecProvider;
             dateStorage = original.dateStorage;
             ignoreFinals = original.ignoreFinals;
             mapSubPackages = original.mapSubPackages;
@@ -385,6 +401,20 @@ public class MapperOptions {
         @MorphiaExperimental
         public Builder codecProvider(CodecProvider codecProvider) {
             this.codecProvider = codecProvider;
+            return this;
+        }
+
+        /**
+         * Sets a provider for user defined codecs to used by Morphia
+         *
+         * @param codecProvider the provider to user
+         * @return this
+         * @morphia.experimental
+         * @since 2.3
+         */
+        @MorphiaExperimental
+        public Builder propertyCodecProvider(PropertyCodecProvider propertyCodecProvider) {
+            this.propertyCodecProvider = propertyCodecProvider;
             return this;
         }
 

--- a/core/src/main/java/dev/morphia/mapping/MapperOptions.java
+++ b/core/src/main/java/dev/morphia/mapping/MapperOptions.java
@@ -139,9 +139,9 @@ public class MapperOptions {
     }
 
     /**
-     * @return the configured CodecProvider
+     * @return the configured PropertyCodecProvider
      * @see CodecProvider
-     * @since 2.3
+     * @since 2.4
      */
     @Nullable
     @MorphiaInternal
@@ -405,12 +405,12 @@ public class MapperOptions {
         }
 
         /**
-         * Sets a provider for user defined codecs to used by Morphia
+         * Sets a property provider for user defined codecs to used by Morphia
          *
-         * @param codecProvider the provider to user
+         * @param propertyCodecProvider the provider to user
          * @return this
          * @morphia.experimental
-         * @since 2.3
+         * @since 2.4
          */
         @MorphiaExperimental
         public Builder propertyCodecProvider(PropertyCodecProvider propertyCodecProvider) {

--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaCodecProvider.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaCodecProvider.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 
 import com.mongodb.lang.Nullable;
 
@@ -44,15 +43,16 @@ public class MorphiaCodecProvider implements CodecProvider {
      *
      * @param datastore the Datastore to use
      */
-    public MorphiaCodecProvider(Datastore datastore) {
+    public MorphiaCodecProvider(Datastore datastore, PropertyCodecProvider propertyCodecProvider) {
         this.datastore = datastore;
         this.mapper = datastore.getMapper();
 
+        if (propertyCodecProvider != null) {
+            propertyCodecProviders.add(propertyCodecProvider);
+        }
+
         propertyCodecProviders.addAll(List.of(new MorphiaMapPropertyCodecProvider(),
                 new MorphiaCollectionPropertyCodecProvider()));
-
-        ServiceLoader<MorphiaPropertyCodecProvider> providers = ServiceLoader.load(MorphiaPropertyCodecProvider.class);
-        providers.forEach(propertyCodecProviders::add);
     }
 
     @Nullable

--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapPropertyCodecProvider.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapPropertyCodecProvider.java
@@ -21,7 +21,7 @@ import org.bson.codecs.pojo.TypeWithTypeParameters;
 import static dev.morphia.aggregation.codecs.ExpressionHelper.document;
 
 @SuppressWarnings("unchecked")
-class MorphiaMapPropertyCodecProvider extends MorphiaPropertyCodecProvider {
+public class MorphiaMapPropertyCodecProvider extends MorphiaPropertyCodecProvider {
     @Override
     public <T> Codec<T> get(TypeWithTypeParameters<T> type, PropertyCodecRegistry registry) {
         if (Map.class.isAssignableFrom(type.getType())) {
@@ -47,12 +47,12 @@ class MorphiaMapPropertyCodecProvider extends MorphiaPropertyCodecProvider {
         return null;
     }
 
-    private static class MapCodec<K, V> implements Codec<Map<K, V>> {
-        private final Class<Map<K, V>> encoderClass;
-        private final Class<K> keyType;
-        private final Codec<V> codec;
+    public static class MapCodec<K, V> implements Codec<Map<K, V>> {
+        protected final Class<Map<K, V>> encoderClass;
+        protected final Class<K> keyType;
+        protected final Codec<V> codec;
 
-        MapCodec(Class<Map<K, V>> encoderClass, Class<K> keyType, Codec<V> codec) {
+        protected MapCodec(Class<Map<K, V>> encoderClass, Class<K> keyType, Codec<V> codec) {
             this.encoderClass = encoderClass;
             this.keyType = keyType;
             this.codec = codec;
@@ -95,7 +95,7 @@ class MorphiaMapPropertyCodecProvider extends MorphiaPropertyCodecProvider {
             return encoderClass;
         }
 
-        private Map<K, V> getInstance() {
+        protected Map<K, V> getInstance() {
             if (encoderClass.isInterface()) {
                 return new HashMap<>();
             }

--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapPropertyCodecProvider.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapPropertyCodecProvider.java
@@ -21,8 +21,9 @@ import org.bson.codecs.pojo.TypeWithTypeParameters;
 import static dev.morphia.aggregation.codecs.ExpressionHelper.document;
 
 @SuppressWarnings("unchecked")
-public class MorphiaMapPropertyCodecProvider extends MorphiaPropertyCodecProvider {
-    @Override
+class MorphiaMapPropertyCodecProvider extends MorphiaPropertyCodecProvider {
+    @SuppressWarnings("rawtypes")
+	@Override
     public <T> Codec<T> get(TypeWithTypeParameters<T> type, PropertyCodecRegistry registry) {
         if (Map.class.isAssignableFrom(type.getType())) {
             final List<? extends TypeWithTypeParameters<?>> typeParameters = type.getTypeParameters();
@@ -47,7 +48,7 @@ public class MorphiaMapPropertyCodecProvider extends MorphiaPropertyCodecProvide
         return null;
     }
 
-    public static class MapCodec<K, V> implements Codec<Map<K, V>> {
+    static class MapCodec<K, V> implements Codec<Map<K, V>> {
         protected final Class<Map<K, V>> encoderClass;
         protected final Class<K> keyType;
         protected final Codec<V> codec;

--- a/core/src/test/java/dev/morphia/mapping/codec/MyPropertyCodecProvider.java
+++ b/core/src/test/java/dev/morphia/mapping/codec/MyPropertyCodecProvider.java
@@ -1,0 +1,53 @@
+package dev.morphia.mapping.codec;
+
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+
+import org.bson.codecs.Codec;
+import org.bson.codecs.pojo.PropertyCodecRegistry;
+import org.bson.codecs.pojo.TypeWithTypeParameters;
+
+import dev.morphia.mapping.codec.MorphiaMapPropertyCodecProvider.MapCodec;
+
+public class MyPropertyCodecProvider extends MorphiaPropertyCodecProvider {
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    public <T> Codec<T> get(TypeWithTypeParameters<T> type, PropertyCodecRegistry registry) {
+        if (type.getType().equals(EnumSet.class)) {
+            return new EnumSetCodec(type.getType(), registry.get(type.getTypeParameters().get(0)));
+        } else if (type.getType().equals(EnumMap.class)) {
+            return new EnumMapCodec(type.getType(), type.getTypeParameters().get(0).getType(),
+                    registry.get(type.getTypeParameters().get(1)));
+        }
+        return null;
+    }
+
+    public static class EnumSetCodec<T> extends CollectionCodec<T> {
+
+        protected EnumSetCodec(Class<Collection<T>> encoderClass, Codec<T> codec) {
+            super(encoderClass, codec);
+        }
+
+        @Override
+        protected Collection<T> getInstance() {
+        	throw new RuntimeException("EnumSet codec registered and found");
+        }
+
+    }
+
+    public static class EnumMapCodec<K, V> extends MapCodec<K, V> {
+
+        EnumMapCodec(Class<Map<K, V>> encoderClass, Class<K> keyType, Codec<V> codec) {
+            super(encoderClass, keyType, codec);
+        }
+
+        @Override
+        protected Map<K, V> getInstance() {
+        	throw new RuntimeException("EnumMap codec registered and found");
+        }
+
+    }
+}

--- a/core/src/test/java/dev/morphia/test/mapping/codec/pojo/PropertyCodecProviderTest.java
+++ b/core/src/test/java/dev/morphia/test/mapping/codec/pojo/PropertyCodecProviderTest.java
@@ -1,54 +1,57 @@
 package dev.morphia.test.mapping.codec.pojo;
 
-import java.util.Collection;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
-import dev.morphia.annotations.Entity;
-import dev.morphia.annotations.Id;
-import dev.morphia.mapping.MapperOptions;
-import dev.morphia.mapping.codec.CollectionCodec;
-import dev.morphia.mapping.codec.EnumCodec;
-import dev.morphia.mapping.codec.MorphiaMapPropertyCodecProvider.MapCodec;
-import dev.morphia.mapping.codec.MorphiaPropertyCodecProvider;
-import dev.morphia.test.TestBase;
-import dev.morphia.test.mapping.codec.pojo.PropertyCodecProviderTest.MyEntity.TheEnum;
-
-import org.bson.codecs.Codec;
-import org.bson.codecs.pojo.PropertyCodecRegistry;
-import org.bson.codecs.pojo.TypeWithTypeParameters;
 import org.bson.types.ObjectId;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import dev.morphia.mapping.MapperOptions;
+import dev.morphia.mapping.codec.MyPropertyCodecProvider;
+import dev.morphia.test.TestBase;
+import dev.morphia.test.mapping.codec.pojo.PropertyCodecProviderTest.MyEntity.TheEnum;
 
 public class PropertyCodecProviderTest extends TestBase {
     public PropertyCodecProviderTest() {
         super(MapperOptions.builder()
-                .propertyCodecProvider(new MyCodecProvider())
+                .propertyCodecProvider(new MyPropertyCodecProvider())
                 .build());
     }
 
     @Test
-    public void testEnumSetPRoperty() {
+    public void testEnumSetAndEnumMapProperty() {
         MyEntity entity = new MyEntity();
         entity.enumSet = EnumSet.of(TheEnum.ONE);
-        entity.enumMap = new EnumMap<>(TheEnum.class);
-        entity.enumMap.put(TheEnum.TWO, "TWO");
-        entity.stringList = List.of("item1");
-        entity.stringMap = Map.of("key", "value");
+        
 
         getDs().save(entity);
 
-        entity = getDs().find(MyEntity.class).first();
-
-        assertEquals(TheEnum.ONE, entity.enumSet.iterator().next());
-        assertEquals("TWO", entity.enumMap.get(TheEnum.TWO));
+        try {
+			entity = getDs().find(MyEntity.class).first();
+			fail("should throw exception");
+		} catch (RuntimeException e) {
+			assertEquals(e.getMessage(), "EnumSet codec registered and found");
+		}
         
-        assertEquals("item1", entity.stringList.iterator().next());
-        assertEquals("value", entity.stringMap.get("key"));
+        entity.enumMap = new EnumMap<>(TheEnum.class);
+        entity.enumMap.put(TheEnum.TWO, "TWO");
+        entity.enumSet = null;
+        
+        getDs().save(entity);
+
+        try {
+			entity = getDs().find(MyEntity.class).first();
+			fail("should throw exception");
+		} catch (RuntimeException e) {
+			assertEquals(e.getMessage(), "EnumMap codec registered and found");
+		}
     }
 
     @Entity
@@ -65,49 +68,6 @@ public class PropertyCodecProviderTest extends TestBase {
         public enum TheEnum {
             ONE,
             TWO
-        }
-    }
-
-    public static class MyCodecProvider extends MorphiaPropertyCodecProvider {
-
-        @SuppressWarnings({ "rawtypes", "unchecked" })
-        @Override
-        public <T> Codec<T> get(TypeWithTypeParameters<T> type, PropertyCodecRegistry registry) {
-            if (type.getType().equals(EnumSet.class)) {
-                return new EnumSetCodec(type.getType(), registry.get(type.getTypeParameters().get(0)));
-            } else if (type.getType().equals(EnumMap.class)) {
-                return new EnumMapCodec(type.getType(), type.getTypeParameters().get(0).getType(),
-                        registry.get(type.getTypeParameters().get(1)));
-            }
-            return null;
-        }
-
-        public static class EnumSetCodec<T> extends CollectionCodec<T> {
-
-            protected EnumSetCodec(Class<Collection<T>> encoderClass, Codec<T> codec) {
-                super(encoderClass, codec);
-            }
-
-            @SuppressWarnings({ "unchecked", "rawtypes" })
-            @Override
-            protected Collection<T> getInstance() {
-                return EnumSet.noneOf(((EnumCodec) getCodec()).getEncoderClass());
-            }
-
-        }
-
-        public static class EnumMapCodec<K, V> extends MapCodec<K, V> {
-
-            EnumMapCodec(Class<Map<K, V>> encoderClass, Class<K> keyType, Codec<V> codec) {
-                super(encoderClass, keyType, codec);
-            }
-
-            @SuppressWarnings({ "unchecked", "rawtypes" })
-            @Override
-            protected Map<K, V> getInstance() {
-                return new EnumMap(keyType);
-            }
-
         }
     }
 }

--- a/core/src/test/java/dev/morphia/test/mapping/codec/pojo/PropertyCodecProviderTest.java
+++ b/core/src/test/java/dev/morphia/test/mapping/codec/pojo/PropertyCodecProviderTest.java
@@ -1,0 +1,113 @@
+package dev.morphia.test.mapping.codec.pojo;
+
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import dev.morphia.mapping.MapperOptions;
+import dev.morphia.mapping.codec.CollectionCodec;
+import dev.morphia.mapping.codec.EnumCodec;
+import dev.morphia.mapping.codec.MorphiaMapPropertyCodecProvider.MapCodec;
+import dev.morphia.mapping.codec.MorphiaPropertyCodecProvider;
+import dev.morphia.test.TestBase;
+import dev.morphia.test.mapping.codec.pojo.PropertyCodecProviderTest.MyEntity.TheEnum;
+
+import org.bson.codecs.Codec;
+import org.bson.codecs.pojo.PropertyCodecRegistry;
+import org.bson.codecs.pojo.TypeWithTypeParameters;
+import org.bson.types.ObjectId;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class PropertyCodecProviderTest extends TestBase {
+    public PropertyCodecProviderTest() {
+        super(MapperOptions.builder()
+                .propertyCodecProvider(new MyCodecProvider())
+                .build());
+    }
+
+    @Test
+    public void testEnumSetPRoperty() {
+        MyEntity entity = new MyEntity();
+        entity.enumSet = EnumSet.of(TheEnum.ONE);
+        entity.enumMap = new EnumMap<>(TheEnum.class);
+        entity.enumMap.put(TheEnum.TWO, "TWO");
+        entity.stringList = List.of("item1");
+        entity.stringMap = Map.of("key", "value");
+
+        getDs().save(entity);
+
+        entity = getDs().find(MyEntity.class).first();
+
+        assertEquals(TheEnum.ONE, entity.enumSet.iterator().next());
+        assertEquals("TWO", entity.enumMap.get(TheEnum.TWO));
+        
+        assertEquals("item1", entity.stringList.iterator().next());
+        assertEquals("value", entity.stringMap.get("key"));
+    }
+
+    @Entity
+    public static class MyEntity {
+        @Id
+        public ObjectId id;
+
+        public EnumSet<TheEnum> enumSet;
+        public EnumMap<TheEnum, String> enumMap;
+        
+        public List<String> stringList;
+        public Map<String, String> stringMap;
+
+        public enum TheEnum {
+            ONE,
+            TWO
+        }
+    }
+
+    public static class MyCodecProvider extends MorphiaPropertyCodecProvider {
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        @Override
+        public <T> Codec<T> get(TypeWithTypeParameters<T> type, PropertyCodecRegistry registry) {
+            if (type.getType().equals(EnumSet.class)) {
+                return new EnumSetCodec(type.getType(), registry.get(type.getTypeParameters().get(0)));
+            } else if (type.getType().equals(EnumMap.class)) {
+                return new EnumMapCodec(type.getType(), type.getTypeParameters().get(0).getType(),
+                        registry.get(type.getTypeParameters().get(1)));
+            }
+            return null;
+        }
+
+        public static class EnumSetCodec<T> extends CollectionCodec<T> {
+
+            protected EnumSetCodec(Class<Collection<T>> encoderClass, Codec<T> codec) {
+                super(encoderClass, codec);
+            }
+
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            @Override
+            protected Collection<T> getInstance() {
+                return EnumSet.noneOf(((EnumCodec) getCodec()).getEncoderClass());
+            }
+
+        }
+
+        public static class EnumMapCodec<K, V> extends MapCodec<K, V> {
+
+            EnumMapCodec(Class<Map<K, V>> encoderClass, Class<K> keyType, Codec<V> codec) {
+                super(encoderClass, keyType, codec);
+            }
+
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            @Override
+            protected Map<K, V> getInstance() {
+                return new EnumMap(keyType);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
fix registration of property codec providers, right now doesnt work, as it uses java service loader that needs module specifications when using java 9+, so i changed the way of adding provider like it's done with regular codec providers, through the mapper options


the bug reproduced:
https://github.com/daniel-exceed/property-codec-service-loader