### PR TITLE
Flesh out the documentation for the core lifecycle annotations

### DIFF
--- a/core/src/main/java/dev/morphia/annotations/PostLoad.java
+++ b/core/src/main/java/dev/morphia/annotations/PostLoad.java
@@ -8,7 +8,40 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Called after the data has been loaded into the java object.
+ * Called after the data has been loaded into the java object. This is a good place to perform 
+ * initialization and sanity-checking of the object.
+ * <p>
+ * Methods with this annotation may optionally take a parameter of type {@link org.bson.Document Document} 
+ * and/or a parameter of type {@link dev.morphia.Datastore Datastore}. If both parameters are used, 
+ * the order is unimportant.
+ * <p>
+ * The Document parameter (if used) will be the document that this object was loaded from. The Datastore
+ * parameter (if used) will be the datastore this object was loaded from.
+ * <p>
+ * <strong>Example declarations (in order of most to least typical):</strong>
+ * <pre>
+ * {@code @PostLoad}
+ * void cleanUpAfterLoading() {
+ *   // perform initialization here as needed.
+ * }
+ * </pre>
+ * <pre>
+ * {@code @PostLoad}
+ * void examineAdditionalDocumentElements(Document doc) {
+ *   // doc is the Document we were loaded from. Document elements can be examined manually here. 
+ *   // Note that changes to doc will not have any effect (as it's already been read from).
+ * }
+ * </pre>
+ * <pre>
+ * {@code @PostLoad}
+ * void performComplexAdditionalQueriesAfterLoading(Document doc, Datastore datastore) {
+ *   // doc is the Document we were loaded from. datastore is the datastore we were loaded from.
+ * }
+ * </pre>
+ * 
+ * @see dev.morphia.annotations.PreLoad
+ * @see dev.morphia.annotations.PrePersist
+ * @see dev.morphia.annotations.PostPersist
  *
  * @author Scott Hernandez
  */

--- a/core/src/main/java/dev/morphia/annotations/PostLoad.java
+++ b/core/src/main/java/dev/morphia/annotations/PostLoad.java
@@ -8,23 +8,25 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Called after the data has been loaded into the java object. This is a good place to perform 
+ * Called after the data has been loaded into the java object. This is a good place to perform
  * initialization and sanity-checking of the object.
  * <p>
- * Methods with this annotation may optionally take a parameter of type {@link org.bson.Document Document} 
- * and/or a parameter of type {@link dev.morphia.Datastore Datastore}. If both parameters are used, 
+ * Methods with this annotation may optionally take a parameter of type {@link org.bson.Document Document}
+ * and/or a parameter of type {@link dev.morphia.Datastore Datastore}. If both parameters are used,
  * the order is unimportant.
  * <p>
  * The Document parameter (if used) will be the document that this object was loaded from. The Datastore
  * parameter (if used) will be the datastore this object was loaded from.
  * <p>
  * <strong>Example declarations (in order of most to least typical):</strong>
+ * 
  * <pre>
  * {@code @PostLoad}
  * void cleanUpAfterLoading() {
  *   // perform initialization here as needed.
  * }
  * </pre>
+ * 
  * <pre>
  * {@code @PostLoad}
  * void examineAdditionalDocumentElements(Document doc) {
@@ -32,6 +34,7 @@ import java.lang.annotation.Target;
  *   // Note that changes to doc will not have any effect (as it's already been read from).
  * }
  * </pre>
+ * 
  * <pre>
  * {@code @PostLoad}
  * void performComplexAdditionalQueriesAfterLoading(Document doc, Datastore datastore) {

--- a/core/src/main/java/dev/morphia/annotations/PostPersist.java
+++ b/core/src/main/java/dev/morphia/annotations/PostPersist.java
@@ -8,7 +8,35 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Called after the data has been persisted from the java object.
+ * Called after the data has been persisted from the java object. Here you can alter the 
+ * BSON Document before it is saved.
+ * <p>
+ * Methods with this annotation may optionally take a parameter of type {@link org.bson.Document Document} 
+ * and/or a parameter of type {@link dev.morphia.Datastore Datastore}. If both parameters are used, the
+ * order is unimportant. For typical usage, the method should take a Document parameter.
+ * <p>
+ * The Document parameter (if used) will be the document that this object was saved to. You can alter 
+ * the Document to change how it will be saved. The Datastore parameter (if used) will be the
+ * Datastore this Document will be saved to.
+ * <p>
+ * <strong>Example declarations (in order of most to least typical):</strong>
+ * <pre>
+ * {@code @PostPersist}
+ * private void removeUnneededDataFromDoc(Document doc) {
+ *   // doc is the Document this object was written to. It can be altered here prior to saving.
+ * }
+ * </pre>
+ * <pre>
+ * {@code @PostPersist}
+ * private void performAdditionalQueriesBeforeSaving(Document doc, Datastore datastore) {
+ *   // doc is the Document this object was written to. datastore is where it will be saved in.
+ *   // doc can be altered here prior to saving.
+ * }
+ * </pre>
+ *
+ * @see dev.morphia.annotations.PreLoad
+ * @see dev.morphia.annotations.PostLoad
+ * @see dev.morphia.annotations.PrePersist
  *
  * @author Scott Hernandez
  */

--- a/core/src/main/java/dev/morphia/annotations/PostPersist.java
+++ b/core/src/main/java/dev/morphia/annotations/PostPersist.java
@@ -8,24 +8,26 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Called after the data has been persisted from the java object. Here you can alter the 
+ * Called after the data has been persisted from the java object. Here you can alter the
  * BSON Document before it is saved.
  * <p>
- * Methods with this annotation may optionally take a parameter of type {@link org.bson.Document Document} 
+ * Methods with this annotation may optionally take a parameter of type {@link org.bson.Document Document}
  * and/or a parameter of type {@link dev.morphia.Datastore Datastore}. If both parameters are used, the
  * order is unimportant. For typical usage, the method should take a Document parameter.
  * <p>
- * The Document parameter (if used) will be the document that this object was saved to. You can alter 
+ * The Document parameter (if used) will be the document that this object was saved to. You can alter
  * the Document to change how it will be saved. The Datastore parameter (if used) will be the
  * Datastore this Document will be saved to.
  * <p>
  * <strong>Example declarations (in order of most to least typical):</strong>
+ * 
  * <pre>
  * {@code @PostPersist}
  * private void removeUnneededDataFromDoc(Document doc) {
  *   // doc is the Document this object was written to. It can be altered here prior to saving.
  * }
  * </pre>
+ * 
  * <pre>
  * {@code @PostPersist}
  * private void performAdditionalQueriesBeforeSaving(Document doc, Datastore datastore) {

--- a/core/src/main/java/dev/morphia/annotations/PreLoad.java
+++ b/core/src/main/java/dev/morphia/annotations/PreLoad.java
@@ -11,21 +11,23 @@ import java.lang.annotation.Target;
  * Called before the data has been loaded into the object. Here you can alter the raw BSON Document from the
  * datastore prior to object initialization.
  * <p>
- * Methods with this annotation may optionally take a parameter of type {@link org.bson.Document Document} 
+ * Methods with this annotation may optionally take a parameter of type {@link org.bson.Document Document}
  * and/or a parameter of type {@link dev.morphia.Datastore Datastore}. If both parameters are used, the
  * order is unimportant. For typical usage, the method should take a Document parameter.
  * <p>
- * The Document parameter (if used) will be the document that this object will be loaded from. You can alter 
- * the Document here and those changes will be reflected when the object is loaded. The Datastore parameter 
+ * The Document parameter (if used) will be the document that this object will be loaded from. You can alter
+ * the Document here and those changes will be reflected when the object is loaded. The Datastore parameter
  * (if used) will be the Datastore this Document was loaded from.
  * <p>
  * <strong>Example declarations (in order of most to least typical):</strong>
+ * 
  * <pre>
  * {@code @PreLoad}
  * private void fixupDocument(Document doc) {
  *   // doc is the Document we will be initialized from. Document elements can be manually changed or removed.
  * }
  * </pre>
+ * 
  * <pre>
  * {@code @PreLoad}
  * private void performAdditionalQueriesBeforeLoading(Document doc, Datastore datastore) {

--- a/core/src/main/java/dev/morphia/annotations/PreLoad.java
+++ b/core/src/main/java/dev/morphia/annotations/PreLoad.java
@@ -8,7 +8,34 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Called before the data has been loaded from the datastore.
+ * Called before the data has been loaded into the object. Here you can alter the raw BSON Document from the
+ * datastore prior to object initialization.
+ * <p>
+ * Methods with this annotation may optionally take a parameter of type {@link org.bson.Document Document} 
+ * and/or a parameter of type {@link dev.morphia.Datastore Datastore}. If both parameters are used, the
+ * order is unimportant. For typical usage, the method should take a Document parameter.
+ * <p>
+ * The Document parameter (if used) will be the document that this object will be loaded from. You can alter 
+ * the Document here and those changes will be reflected when the object is loaded. The Datastore parameter 
+ * (if used) will be the Datastore this Document was loaded from.
+ * <p>
+ * <strong>Example declarations (in order of most to least typical):</strong>
+ * <pre>
+ * {@code @PreLoad}
+ * private void fixupDocument(Document doc) {
+ *   // doc is the Document we will be initialized from. Document elements can be manually changed or removed.
+ * }
+ * </pre>
+ * <pre>
+ * {@code @PreLoad}
+ * private void performAdditionalQueriesBeforeLoading(Document doc, Datastore datastore) {
+ *   // doc is the Document we will be loaded from. datastore is the datastore the Document originated from.
+ * }
+ * </pre>
+ * 
+ * @see dev.morphia.annotations.PostLoad
+ * @see dev.morphia.annotations.PrePersist
+ * @see dev.morphia.annotations.PostPersist
  *
  * @author Scott Hernandez
  */

--- a/core/src/main/java/dev/morphia/annotations/PrePersist.java
+++ b/core/src/main/java/dev/morphia/annotations/PrePersist.java
@@ -8,7 +8,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Called before the data has been persisted to the datastore (before mapping is done).
+ * Called before the data has been persisted to the datastore (before mapping is done). 
+ * Here you can alter your class members prior to being saved.
+ * <p>
+ * <strong>Example declaration:</strong>
+ * <pre>
+ * {@code @PrePersist}
+ * void cleanUpBeforeSaving() {
+ *   // perform variable sanitization here as needed
+ * }
+ * </pre>
+ * 
+ * @see dev.morphia.annotations.PreLoad
+ * @see dev.morphia.annotations.PostLoad
+ * @see dev.morphia.annotations.PostPersist
  *
  * @author Scott Hernandez
  */

--- a/core/src/main/java/dev/morphia/annotations/PrePersist.java
+++ b/core/src/main/java/dev/morphia/annotations/PrePersist.java
@@ -8,14 +8,26 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Called before the data has been persisted to the datastore (before mapping is done). 
+ * Called before the data has been persisted to the datastore (before mapping is done).
  * Here you can alter your class members prior to being saved.
  * <p>
- * <strong>Example declaration:</strong>
+ * Methods with this annotation may optionally take a parameter of type
+ * {@link dev.morphia.Datastore Datastore}. This is the Datastore that
+ * data will be persisted to.
+ * <p>
+ * <strong>Example declarations (in order of most to least typical):</strong>
+ * 
  * <pre>
  * {@code @PrePersist}
  * void cleanUpBeforeSaving() {
  *   // perform variable sanitization here as needed
+ * }
+ * </pre>
+ * 
+ * <pre>
+ * {@code @PrePersist}
+ * void retrieveOtherInfoBeforeSaving(Datastore datastore) {
+ *   // query datastore as needed
  * }
  * </pre>
  * 


### PR DESCRIPTION
No code changes -- just some documentation tweaks. The lifecycle document is a good start, but I still had questions about how each annotation worked, and documenting the annotations seems like the best place to put more info. (It's where I looked first, anyway.)

I tried to only use examples that could be potentially useful -- for example, I didn't add examples of @PostPersist functions that take zero parameters, because I couldn't think of any situation where that would be useful.

This is just a draft -- open to alterations.