### PR TITLE
BitSet codec

### DIFF
--- a/core/src/main/java/dev/morphia/mapping/codec/BitSetCodec.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/BitSetCodec.java
@@ -75,11 +75,11 @@ public class BitSetCodec implements Codec<BitSet> {
             }
         }
         reader.readEndDocument();
-        
+
         if (!foundKey) {
             throw new IllegalStateException("Expected BitSet BSON to contain a field named '" + LEGACY_ARRAY_KEY + "', but not found!");
         }
-        
+
         return BitSet.valueOf(toArray(temp));
     }
 

--- a/core/src/main/java/dev/morphia/mapping/codec/BitSetCodec.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/BitSetCodec.java
@@ -17,9 +17,9 @@ import org.bson.codecs.EncoderContext;
  * <p>
  * For compatibility with the legacy MongoDB driver, the codec can
  * also decode a BitSet from a document if it contains a key named "words"
- * which contains the array of longs. Note that this legacy format is only used
- * when LOADING a BitSet. When persisting a BitSet, it is always stored as an
- * array of long integers.
+ * whose value is an array of longs. Note that this legacy format is only
+ * available when LOADING a BitSet. When persisting a BitSet, it is always
+ * stored as an array of long integers.
  */
 public class BitSetCodec implements Codec<BitSet> {
     private static final String LEGACY_ARRAY_KEY = "words";

--- a/core/src/main/java/dev/morphia/mapping/codec/BitSetCodec.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/BitSetCodec.java
@@ -87,9 +87,9 @@ public class BitSetCodec implements Codec<BitSet> {
     }
 
     /**
-     * Converts a list of Longs to an array of Longs.
+     * Converts a list of Longs to an array of longs.
      */
-    private long[] toArray(List<Long> list) {
+    private static long[] toArray(List<Long> list) {
         var ret = new long[list.size()];
         for (int i = 0; i < list.size(); ++i) {
             ret[i] = list.get(i);

--- a/core/src/main/java/dev/morphia/mapping/codec/BitSetCodec.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/BitSetCodec.java
@@ -48,10 +48,12 @@ public class BitSetCodec implements Codec<BitSet> {
 
     private BitSet decodeLegacy(BsonReader reader, DecoderContext decoderContext) {
         List<Long> temp = new ArrayList<>();
+        boolean foundKey = false;
         reader.readStartDocument();
         while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
             String fieldName = reader.readName();
             if (fieldName.equals(LEGACY_ARRAY_KEY)) {
+                foundKey = true;
                 reader.readStartArray();
                 while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
                     temp.add(reader.readInt64());
@@ -73,6 +75,11 @@ public class BitSetCodec implements Codec<BitSet> {
             }
         }
         reader.readEndDocument();
+        
+        if (!foundKey) {
+            throw new IllegalStateException("Expected BitSet BSON to contain a field named '" + LEGACY_ARRAY_KEY + "', but not found!");
+        }
+        
         return BitSet.valueOf(toArray(temp));
     }
 

--- a/core/src/main/java/dev/morphia/mapping/codec/BitSetCodec.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/BitSetCodec.java
@@ -1,0 +1,105 @@
+package dev.morphia.mapping.codec;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+
+/**
+ * Defines a codec for standard {@link java.util.BitSet}. BitSet is
+ * encoded/decoded a an array of long integers.
+ * <p>
+ * For compatibility with the legacy MongoDB driver, the codec can
+ * also decode a BitSet from a document if it contains a key named "words"
+ * which contains the array of longs. Note that this legacy format is only used
+ * when LOADING a BitSet. When persisting a BitSet, it is always stored as an
+ * array of long integers.
+ */
+public class BitSetCodec implements Codec<BitSet> {
+    private static final String LEGACY_ARRAY_KEY = "words";
+
+    @Override
+    public void encode(BsonWriter writer, BitSet value, EncoderContext encoderContext) {
+        writer.writeStartArray();
+        long[] longs = value.toLongArray();
+        for (int i = 0; i < longs.length; ++i) {
+            writer.writeInt64(longs[i]);
+        }
+        writer.writeEndArray();
+    }
+
+    @Override
+    public BitSet decode(BsonReader reader, DecoderContext decoderContext) {
+        var currentType = reader.getCurrentBsonType();
+        if (currentType == BsonType.DOCUMENT) {
+            return decodeLegacy(reader, decoderContext);
+        } else if (currentType == BsonType.ARRAY) {
+            return decodeModern(reader, decoderContext);
+        } else {
+            throw new IllegalStateException("cannot decode BitSet from " + currentType);
+        }
+    }
+
+    private BitSet decodeLegacy(BsonReader reader, DecoderContext decoderContext) {
+        List<Long> temp = new ArrayList<>();
+        reader.readStartDocument();
+        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+            String fieldName = reader.readName();
+            if (fieldName.equals(LEGACY_ARRAY_KEY)) {
+                reader.readStartArray();
+                while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                    temp.add(reader.readInt64());
+                }
+                reader.readEndArray();
+            } else {
+                // the legacy encoder also encoded the private members of BitSet, which we ignore here: "wordsInUse" (int) and "sizeIsStick" (bool)
+                switch (reader.getCurrentBsonType()) {
+                    case INT32:
+                        reader.readInt32();
+                        break;
+                    case BOOLEAN:
+                        reader.readBoolean();
+                        break;
+                    default:
+                        throw new IllegalStateException(
+                                "BitSetCodec can't decode field '" + fieldName + "' of type " + reader.getCurrentBsonType());
+                }
+            }
+        }
+        reader.readEndDocument();
+        return BitSet.valueOf(toArray(temp));
+    }
+
+    private BitSet decodeModern(BsonReader reader, DecoderContext decoderContext) {
+        List<Long> temp = new ArrayList<>();
+        reader.readStartArray();
+        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+            temp.add(reader.readInt64());
+        }
+        reader.readEndArray();
+        return BitSet.valueOf(toArray(temp));
+    }
+
+    /**
+     * Converts a list of Longs to an array of Longs.
+     */
+    private long[] toArray(List<Long> list) {
+        var ret = new long[list.size()];
+        for (int i = 0; i < list.size(); ++i) {
+            ret[i] = list.get(i);
+        }
+        return ret;
+    }
+
+    @Override
+    public Class<BitSet> getEncoderClass() {
+        return BitSet.class;
+    }
+
+}

--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaTypesCodecProvider.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaTypesCodecProvider.java
@@ -42,6 +42,7 @@ public class MorphiaTypesCodecProvider implements CodecProvider {
         addCodec(new URICodec());
         addCodec(new ByteWrapperArrayCodec());
         addCodec(new LegacyQueryCodec(datastore));
+        addCodec(new BitSetCodec());
 
         List.of(boolean.class, Boolean.class,
                 char.class, Character.class,

--- a/core/src/test/java/dev/morphia/test/mapping/codec/BitSetCodecTest.java
+++ b/core/src/test/java/dev/morphia/test/mapping/codec/BitSetCodecTest.java
@@ -21,7 +21,10 @@ public class BitSetCodecTest extends TestBase {
     public static class ClassWithBitSet {
         public @Id Long id;
         public BitSet bits;
-        ClassWithBitSet() {}
+
+        ClassWithBitSet() {
+        }
+
         ClassWithBitSet(long id, BitSet bits) {
             this.id = id;
             this.bits = bits;

--- a/core/src/test/java/dev/morphia/test/mapping/codec/BitSetCodecTest.java
+++ b/core/src/test/java/dev/morphia/test/mapping/codec/BitSetCodecTest.java
@@ -1,0 +1,74 @@
+package dev.morphia.test.mapping.codec;
+
+import java.util.BitSet;
+import java.util.List;
+
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import dev.morphia.query.filters.Filters;
+import dev.morphia.test.TestBase;
+
+import org.bson.Document;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class BitSetCodecTest extends TestBase {
+
+    @Entity(value = "ClassWithBitSet")
+    public static class ClassWithBitSet {
+        public @Id Long id = Long.valueOf(1);
+        public BitSet bits = new BitSet();
+    }
+
+    @Test
+    public void testBitSetBasicUsage() {
+        ClassWithBitSet testClass = new ClassWithBitSet();
+        testClass.bits.set(4);
+        testClass.bits.set(44);
+        getDs().save(testClass);
+        getMapper().map(ClassWithBitSet.class);
+
+        ClassWithBitSet found = getDs().find(ClassWithBitSet.class).filter(Filters.eq("id", testClass.id)).first();
+        assertEquals(found.bits.get(3), false);
+        assertEquals(found.bits.get(4), true);
+        assertEquals(found.bits.get(5), false);
+        assertEquals(found.bits.get(43), false);
+        assertEquals(found.bits.get(44), true);
+        assertEquals(found.bits.get(45), false);
+    }
+
+    @Test
+    public void testBitSetEmptyCase() {
+        ClassWithBitSet testClass = new ClassWithBitSet();
+        getDs().save(testClass);
+        getMapper().map(ClassWithBitSet.class);
+
+        ClassWithBitSet found = getDs().find(ClassWithBitSet.class).filter(Filters.eq("id", testClass.id)).first();
+        for (int i = 0; i < found.bits.size(); ++i) {
+            assertEquals(found.bits.get(i), false);
+        }
+    }
+
+    @Test
+    public void testBitSetDecodeLegacyFormat() {
+        String bitSetInLegacyFormat = "{\"words\": [{\"$numberLong\": \"16\"}, {\"$numberLong\": \"-3\"}], \"wordsInUse\": {\"$numberInt\": \"2\"}, \"sizeIsSticky\":false}";
+        String containingObject = "{\"_id\":{\"$numberLong\":\"2\"}, \"_t\":\"ClassWithBitSet\", \"bits\":" + bitSetInLegacyFormat + "}";
+
+        // insert our legacy-formatted document
+        insert("ClassWithBitSet", List.of(Document.parse(containingObject)));
+
+        // retrieve document, make sure it's still the same
+        getMapper().map(ClassWithBitSet.class);
+        ClassWithBitSet result = getDs().find(ClassWithBitSet.class).filter(Filters.eq("_id", 2L)).first();
+        assertNotNull(result);
+        assertEquals(result.bits.get(3), false);
+        assertEquals(result.bits.get(4), true);
+        assertEquals(result.bits.get(5), false);
+        assertEquals(result.bits.get(64), true);
+        assertEquals(result.bits.get(65), false);
+        assertEquals(result.bits.get(66), true);
+    }
+
+}


### PR DESCRIPTION
Adds a codec for `java.util.BitSet` as an array of longs. I've also added support for the legacy driver's save format, as that was very helpful to me when upgrading from Morphia 1.X. This gives users an automatic conversion path if they're still on 1.6 or earlier.