### PR TITLE
Adding the Maven build cache extension. 

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+    <extension>
+        <groupId>org.apache.maven.extensions</groupId>
+        <artifactId>maven-build-cache-extension</artifactId>
+        <version>1.1.0</version>
+    </extension>
+</extensions>


### PR DESCRIPTION
This should speed up builds, particularly when changes are limited to just one module. This extension is open source and free to use.

Currently the Morphia full project build (clean verify) is taking 4-9 minutes locally. Using the build cache:
 - If you make no changes to the code, the project takes 8 seconds to run (locally). I appreciate this is not super useful since one usually wants to make changes! But without the build cache, this would take the full 4-8 minutes
 - If you make a change to Morphia core, the build may take as much time as it usually does, perhaps a little less
 - If you make changes to non-core modules or test classes only, the build may take less time, although I have less experience with how the open source build cache works so this would need some investigation

Feel free to reject this pull request if you think this won't give any benefit or if you want to do some more investigation before applying a new plugin.