### PR TITLE
Prefer to load custom property codec providers before default codec providers.

### DIFF
--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaCodecProvider.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaCodecProvider.java
@@ -48,13 +48,14 @@ public class MorphiaCodecProvider implements CodecProvider {
         this.datastore = datastore;
         this.mapper = datastore.getMapper();
 
-        propertyCodecProviders.addAll(List.of(new MorphiaMapPropertyCodecProvider(),
-                new MorphiaCollectionPropertyCodecProvider()));
-
+        // Load user-provided custom codecs first, to prevent the defaults from overriding them.
         ServiceLoader<MorphiaPropertyCodecProvider> providers = ServiceLoader.load(MorphiaPropertyCodecProvider.class);
         providers.forEach(provider -> {
             propertyCodecProviders.add(provider);
         });
+
+        propertyCodecProviders.addAll(List.of(new MorphiaMapPropertyCodecProvider(),
+                new MorphiaCollectionPropertyCodecProvider()));
     }
 
     protected Map<Class<?>, Codec<?>> getCodecs() {

--- a/core/src/test/java/dev/morphia/mapping/codec/MorphiaCodecProviderTest.java
+++ b/core/src/test/java/dev/morphia/mapping/codec/MorphiaCodecProviderTest.java
@@ -1,0 +1,29 @@
+package dev.morphia.mapping.codec;
+
+import java.util.List;
+
+import dev.morphia.Datastore;
+import dev.morphia.test.TestBase;
+
+import org.bson.codecs.pojo.PropertyCodecProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class MorphiaCodecProviderTest extends TestBase {
+
+    @Test
+    public void NewMorphiaCodecProvider_NoOpPropertyCodecProviderInConfig_ExpectedOrderOfProvidersReturned() {
+        // given a custom 'no-op' codec is provided in the service configuration
+        // (see META-INF/services/dev.morphia.mapping.codec.MorphiaPropertyCodecProvider)
+        // when we instantiate a morphia codec provider
+        Datastore datastore = getDs();
+        MorphiaCodecProvider provider = new MorphiaCodecProvider(datastore);
+
+        // then we expect that the custom provider we provided is the first codec in the list
+        List<PropertyCodecProvider> providers = provider.getPropertyCodecProviders();
+        assertEquals(providers.size(), 3);
+        assertTrue(providers.get(0) instanceof NoOpMorphiaPropertyCodecProvider);
+    }
+}

--- a/core/src/test/java/dev/morphia/mapping/codec/MorphiaCodecProviderTest.java
+++ b/core/src/test/java/dev/morphia/mapping/codec/MorphiaCodecProviderTest.java
@@ -14,7 +14,7 @@ import static org.testng.AssertJUnit.assertTrue;
 public class MorphiaCodecProviderTest extends TestBase {
 
     @Test
-    public void NewMorphiaCodecProvider_NoOpPropertyCodecProviderInConfig_ExpectedOrderOfProvidersReturned() {
+    public void ensureCustomCodedProvidersComeFirst() {
         // given a custom 'no-op' codec is provided in the service configuration
         // (see META-INF/services/dev.morphia.mapping.codec.MorphiaPropertyCodecProvider)
         // when we instantiate a morphia codec provider

--- a/core/src/test/java/dev/morphia/mapping/codec/NoOpMorphiaPropertyCodecProvider.java
+++ b/core/src/test/java/dev/morphia/mapping/codec/NoOpMorphiaPropertyCodecProvider.java
@@ -1,0 +1,43 @@
+package dev.morphia.mapping.codec;
+
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.pojo.PropertyCodecRegistry;
+import org.bson.codecs.pojo.TypeWithTypeParameters;
+
+public class NoOpMorphiaPropertyCodecProvider extends MorphiaPropertyCodecProvider {
+
+    @Override
+    public <T> Codec<T> get(TypeWithTypeParameters<T> typeWithTypeParameters,
+            PropertyCodecRegistry propertyCodecRegistry) {
+        if (NoOpClass.class.isAssignableFrom(typeWithTypeParameters.getType())) {
+            return (Codec<T>) new NoOpCodec();
+        }
+
+        return null;
+    }
+
+    static class NoOpCodec implements Codec<NoOpClass> {
+
+        @Override
+        public NoOpClass decode(BsonReader bsonReader, DecoderContext decoderContext) {
+            return null;
+        }
+
+        @Override
+        public void encode(BsonWriter bsonWriter, NoOpClass unused, EncoderContext encoderContext) {
+
+        }
+
+        @Override
+        public Class<NoOpClass> getEncoderClass() {
+            return NoOpClass.class;
+        }
+    }
+
+    static class NoOpClass {
+    }
+}

--- a/core/src/test/resources/META-INF/services/dev.morphia.mapping.codec.MorphiaPropertyCodecProvider
+++ b/core/src/test/resources/META-INF/services/dev.morphia.mapping.codec.MorphiaPropertyCodecProvider
@@ -1,0 +1,1 @@
+dev.morphia.mapping.codec.NoOpMorphiaPropertyCodecProvider


### PR DESCRIPTION
Like the PR title says - prefer to load user-defined custom property codec providers before the library default codec providers. This allows users to override default behavior to provide customizable codec logic for `Map` and `Collection` types, as well as their subclasses.

Added a test here to validate that the NoOp provider I added would load correctly, but I had to add it in a package separate from the existing tests to get access to the protected methods. Not sure if that's something I should avoid here, but generally it's considered good practice to have unit tests live in the same package as the source it's testing. I also had to add a `META-INF/services/MorphiaPropertyCodecProvider` file here to add the No-Op codec provider so that the service loader could access it. I tried monkeying around with ways to get it to load for _only_ the test I wrote, but no avail.