### PR TITLE
Enable Test Distribution

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -92,6 +92,18 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <distribution>
+                            <enabled>true</enabled>
+                            <maxLocalExecutors>4</maxLocalExecutors>
+                            <maxRemoteExecutors>0</maxRemoteExecutors>
+                        </distribution>
+                    </properties>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>
                 <version>9.0.1</version>
@@ -183,6 +195,10 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>org.skyscreamer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <sofia.version>0.25</sofia.version>
         <surefire.version>3.1.0</surefire.version>
         <testng.version>7.10.2</testng.version>
+        <junit.testng.engine.version>1.0.5</junit.testng.engine.version>
         <zt.exec.version>1.12</zt.exec.version>
 
         <maven.compiler.target>17</maven.compiler.target>
@@ -171,6 +172,12 @@
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.support</groupId>
+                <artifactId>testng-engine</artifactId>
+                <version>${junit.testng.engine.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Enables Develocity's Test Distribution feature for `morphia-core` allowing tests to execute in parallel with up to 4 local executors. This is comparable to surefire's `forkCount`, but Test Distribution additionally benefits from optimized test partitioning based on historical test execution times.

From testing various numbers of local executors, 4 seems to be a good sweet spot and is conveniently the number of cores available in the GitHub Actions runners.

* [Build scan with Test Distribution DISABLED](https://ge.solutions-team.gradle.com/s/v7ejw3dyvqvcy/tests/overview) - tests took `4m 5.743s` wall-clock time
* [Build scan with Test Distribution ENABLED](https://ge.solutions-team.gradle.com/s/ckfna3bgrwmsk/tests/overview) - tests took `1m 28.6s` wall-clock time