### PR TITLE
Enable Develocity Local Build Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ mongodb-linux*
 .idea/**/gradle.xml
 .idea/**/libraries
 
+# Develocity
+.mvn/.develocity
+
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -35,7 +35,7 @@
     </buildScan>
     <buildCache>
         <local>
-            <enabled>false</enabled>
+            <enabled>true</enabled>
         </local>
         <remote>
             <enabled>false</enabled>


### PR DESCRIPTION
Enable local build caching with Develocity, so that goals whose inputs have not changed do not need to be re-executed. This should help reduce local build times when making contributions to Morphia.

Note that it is required to run the `clean` lifecycle phase (i.e. `./mvnw clean install` vs just `./mvnw install`) to store outputs to the build cache.

Here is a [Build Scan](https://ge.solutions-team.gradle.com/s/pywbxplsnu4be/performance/execution#avoidance-savings-local-build-cache) where changes were made to a class under `morphia-kotlin` showing the local build cache in action.
