### PR TITLE
Revert "Enable Test Distribution"

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -92,18 +92,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <properties>
-                        <distribution>
-                            <enabled>true</enabled>
-                            <maxLocalExecutors>4</maxLocalExecutors>
-                            <maxRemoteExecutors>0</maxRemoteExecutors>
-                        </distribution>
-                    </properties>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>
                 <version>9.0.1</version>
@@ -195,10 +183,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.support</groupId>
-            <artifactId>testng-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>org.skyscreamer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
         <sofia.version>0.25</sofia.version>
         <surefire.version>3.1.0</surefire.version>
         <testng.version>7.10.2</testng.version>
-        <junit.testng.engine.version>1.0.5</junit.testng.engine.version>
         <zt.exec.version>1.12</zt.exec.version>
 
         <maven.compiler.target>17</maven.compiler.target>
@@ -179,12 +178,6 @@
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.support</groupId>
-                <artifactId>testng-engine</artifactId>
-                <version>${junit.testng.engine.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Reverts MorphiaOrg/morphia#3280

Test Distribution requires authentication with Develocity, and was causing builds that validate PRs to fail when run against a fork, since forks do not have access to secrets.

`forkCount` can be used instead to achieve similar behavior (without Test Distribution's optimized test partitioning), and has already been enabled [here](https://github.com/MorphiaOrg/morphia/pull/3068).