### PR TITLE
Fix incorrectly returned value in MorphiaMapCodec.java

### DIFF
--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapCodec.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapCodec.java
@@ -70,7 +70,7 @@ public class MorphiaMapCodec implements Codec<Map> {
         }
 
         reader.readEndDocument();
-        return Map.of();
+        return map;
     }
 
     @Override

--- a/core/src/test/java/dev/morphia/test/mapping/codec/MorphiaMapCodecTest.java
+++ b/core/src/test/java/dev/morphia/test/mapping/codec/MorphiaMapCodecTest.java
@@ -1,12 +1,13 @@
 package dev.morphia.test.mapping.codec;
 
+import java.util.Map;
+
 import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Id;
 import dev.morphia.test.TestBase;
+
 import org.bson.BsonNull;
 import org.testng.annotations.Test;
-
-import java.util.Map;
 
 import static java.util.List.of;
 import static org.testng.Assert.*;
@@ -21,7 +22,6 @@ public class MorphiaMapCodecTest extends TestBase {
     public void testBasicUsagex() {
         var testClass = new SomeClass(1L, "value");
         getDs().save(testClass);
-        getMapper().map(SomeClass.class);
 
         var found = getDs().aggregate(SomeClass.class).execute(Map.class).toList();
         assertNotNull(found);
@@ -37,7 +37,6 @@ public class MorphiaMapCodecTest extends TestBase {
     public void testNullCase() {
         var testClass = new SomeClass(1L, BsonNull.VALUE);
         getDs().save(testClass);
-        getMapper().map(SomeClass.class);
 
         var found = getDs().aggregate(SomeClass.class).execute(Map.class).toList();
         assertNotNull(found);

--- a/core/src/test/java/dev/morphia/test/mapping/codec/MorphiaMapCodecTest.java
+++ b/core/src/test/java/dev/morphia/test/mapping/codec/MorphiaMapCodecTest.java
@@ -1,0 +1,62 @@
+package dev.morphia.test.mapping.codec;
+
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import dev.morphia.test.TestBase;
+import org.bson.BsonNull;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static java.util.List.of;
+import static org.testng.Assert.*;
+
+public class MorphiaMapCodecTest extends TestBase {
+
+    public MorphiaMapCodecTest() {
+        super(buildConfig().packages(of("dev.morphia.test.mapping.codec")));
+    }
+
+    @Test
+    public void testBasicUsagex() {
+        var testClass = new SomeClass(1L, "value");
+        getDs().save(testClass);
+        getMapper().map(SomeClass.class);
+
+        var found = getDs().aggregate(SomeClass.class).execute(Map.class).toList();
+        assertNotNull(found);
+        assertEquals(found.size(), 1);
+        var value = found.get(0);
+        assertEquals(value.size(), 3);
+        assertEquals(value.get("data"), "value");
+        assertEquals(value.get("_id"), 1L);
+        assertEquals(value.get("_t"), SomeClass.class.getName());
+    }
+
+    @Test
+    public void testNullCase() {
+        var testClass = new SomeClass(1L, BsonNull.VALUE);
+        getDs().save(testClass);
+        getMapper().map(SomeClass.class);
+
+        var found = getDs().aggregate(SomeClass.class).execute(Map.class).toList();
+        assertNotNull(found);
+        assertEquals(found.size(), 1);
+        var value = found.get(0);
+        assertEquals(value.size(), 3);
+        assertNull(value.get("data"));
+        assertEquals(value.get("_id"), 1L);
+        assertEquals(value.get("_t"), SomeClass.class.getName());
+    }
+
+    @Entity(value = "SomeClass")
+    static class SomeClass {
+        public SomeClass(Long id, Object data) {
+            this.id = id;
+            this.data = data;
+        }
+
+        public @Id Long id;
+        public Object data;
+    }
+}

--- a/core/src/test/java/dev/morphia/test/mapping/codec/MorphiaMapCodecTest.java
+++ b/core/src/test/java/dev/morphia/test/mapping/codec/MorphiaMapCodecTest.java
@@ -19,7 +19,7 @@ public class MorphiaMapCodecTest extends TestBase {
     }
 
     @Test
-    public void testBasicUsagex() {
+    public void testBasicUsage() {
         var testClass = new SomeClass(1L, "value");
         getDs().save(testClass);
 


### PR DESCRIPTION
We've noticed a bug in `MorphiaMapCodec.java` that is it does not return the map it creates but rather always `Map.of()`

This PR fixes that. Test included.

From the user's perspective it's a regression when switching from 2.4.x to 2.5.x

But is especially visible when using `aggregate` and mapping into `Map.class` type.
