### PR TITLE
ensure FindOptions are applied in stream() method

### DIFF
--- a/core/src/main/java/dev/morphia/query/MorphiaQuery.java
+++ b/core/src/main/java/dev/morphia/query/MorphiaQuery.java
@@ -209,7 +209,7 @@ public class MorphiaQuery<T> implements Query<T> {
 
     @Override
     public Stream<T> stream() {
-        Spliterator<T> spliterator = Spliterators.spliteratorUnknownSize(iterator(), 0);
+        Spliterator<T> spliterator = Spliterators.spliteratorUnknownSize(iterator(options), 0);
         return StreamSupport.stream(spliterator, false);
     }
 


### PR DESCRIPTION
This fixes the stream() method in MorphiaQuery to correctly apply FindOptions.