### PR TITLE
feat: Avoid throwing NotMappableExceptions when exceptions are ignored

### DIFF
--- a/core/src/main/java/dev/morphia/internal/PathTarget.java
+++ b/core/src/main/java/dev/morphia/internal/PathTarget.java
@@ -24,7 +24,6 @@ import com.mongodb.lang.Nullable;
 
 import dev.morphia.annotations.internal.MorphiaInternal;
 import dev.morphia.mapping.Mapper;
-import dev.morphia.mapping.NotMappableException;
 import dev.morphia.mapping.codec.pojo.EntityModel;
 import dev.morphia.mapping.codec.pojo.PropertyModel;
 import dev.morphia.query.ValidationException;
@@ -207,11 +206,7 @@ public class PathTarget {
             }
 
             if (model != null) {
-                try {
-                    context = mapper.getEntityModel(model.getNormalizedType());
-                } catch (NotMappableException ignored) {
-                    context = null;
-                }
+                context = mapper.tryGetEntityModel(model.getNormalizedType()).orElse(null);
             }
             return model;
         } else {

--- a/core/src/main/java/dev/morphia/mapping/Mapper.java
+++ b/core/src/main/java/dev/morphia/mapping/Mapper.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -242,6 +243,33 @@ public class Mapper {
     }
 
     /**
+     * Tries to get the {@link EntityModel} for the object (type). If it isn't mapped, but can be mapped, create a new
+     * class and cache it (without validating). If it isn't mapped and cannot be mapped, return empty.
+     *
+     * @param type the type to process
+     * @return optional EntityModel for the object given or empty
+     * @hidden
+     * @morphia.internal
+     */
+    @MorphiaInternal
+    public Optional<EntityModel> tryGetEntityModel(Class type) {
+        final Class actual = MorphiaProxy.class.isAssignableFrom(type) ? type.getSuperclass() : type;
+        if (actual == null && MorphiaProxy.class.equals(type)) {
+            return Optional.empty();
+        }
+        EntityModel model = mappedEntities.get(actual.getName());
+
+        if (model == null) {
+            if (!isMappable(actual)) {
+                return Optional.empty();
+            }
+            model = mapEntity(type);
+        }
+
+        return Optional.of(model);
+    }
+
+    /**
      * Gets the {@link EntityModel} for the object (type). If it isn't mapped, create a new class and cache it (without validating).
      *
      * @param type the type to process
@@ -251,20 +279,8 @@ public class Mapper {
      */
     @MorphiaInternal
     public EntityModel getEntityModel(Class type) {
-        final Class actual = MorphiaProxy.class.isAssignableFrom(type) ? type.getSuperclass() : type;
-        if (actual == null && MorphiaProxy.class.equals(type)) {
-            throw new NotMappableException(type);
-        }
-        EntityModel model = mappedEntities.get(actual.getName());
-
-        if (model == null) {
-            if (!isMappable(actual)) {
-                throw new NotMappableException(type);
-            }
-            model = mapEntity(type);
-        }
-
-        return model;
+        return tryGetEntityModel(type)
+                .orElseThrow(() -> new NotMappableException(type));
     }
 
     @Nullable
@@ -287,16 +303,10 @@ public class Mapper {
         if (entity == null) {
             return null;
         }
-        try {
-            final EntityModel model = getEntityModel(entity.getClass());
-            final PropertyModel idField = model.getIdProperty();
-            if (idField != null) {
-                return idField.getValue(entity);
-            }
-        } catch (NotMappableException ignored) {
-        }
-
-        return null;
+        return tryGetEntityModel(entity.getClass())
+                .map(EntityModel::getIdProperty)
+                .map((idField) -> idField.getValue(entity))
+                .orElse(null);
     }
 
     /**
@@ -448,12 +458,7 @@ public class Mapper {
         Sofia.logConfiguredOperation("Mapper#mapPackage");
         try {
             getClasses(contextClassLoader, packageName)
-                    .forEach(type -> {
-                        try {
-                            getEntityModel(type);
-                        } catch (NotMappableException ignored) {
-                        }
-                    });
+                    .forEach(this::tryGetEntityModel);
         } catch (ClassNotFoundException e) {
             throw new MappingException("Could not get map classes from package " + packageName, e);
         }

--- a/core/src/main/java/dev/morphia/mapping/validation/fieldrules/ReferenceToUnidentifiable.java
+++ b/core/src/main/java/dev/morphia/mapping/validation/fieldrules/ReferenceToUnidentifiable.java
@@ -4,7 +4,6 @@ import java.util.Set;
 
 import dev.morphia.annotations.Reference;
 import dev.morphia.mapping.Mapper;
-import dev.morphia.mapping.NotMappableException;
 import dev.morphia.mapping.codec.pojo.EntityModel;
 import dev.morphia.mapping.codec.pojo.PropertyModel;
 import dev.morphia.mapping.validation.ConstraintViolation;
@@ -21,9 +20,7 @@ public class ReferenceToUnidentifiable extends PropertyConstraint {
         if (propertyModel.hasAnnotation(Reference.class)) {
             final Class realType = propertyModel.getNormalizedType();
 
-            try {
-                mapper.getEntityModel(realType);
-            } catch (NotMappableException ignored) {
+            if (!mapper.tryGetEntityModel(realType).isPresent()) {
                 ve.add(new ConstraintViolation(Level.FATAL, entityModel, propertyModel, getClass(),
                         Sofia.referredTypeMissingId(propertyModel.getFullName(), propertyModel.getType().getName())));
             }

--- a/core/src/main/java/dev/morphia/query/FindOptions.java
+++ b/core/src/main/java/dev/morphia/query/FindOptions.java
@@ -19,7 +19,6 @@ import dev.morphia.internal.CollectionConfigurable;
 import dev.morphia.internal.PathTarget;
 import dev.morphia.internal.ReadConfigurable;
 import dev.morphia.mapping.Mapper;
-import dev.morphia.mapping.NotMappableException;
 import dev.morphia.mapping.codec.pojo.EntityModel;
 import dev.morphia.sofia.Sofia;
 
@@ -141,11 +140,7 @@ public final class FindOptions implements ReadConfigurable<FindOptions>, Collect
         iterable.skip(skip);
         if (sort != null) {
             Document mapped = new Document();
-            EntityModel model = null;
-            try {
-                model = mapper.getEntityModel(type);
-            } catch (NotMappableException ignored) {
-            }
+            EntityModel model = mapper.tryGetEntityModel(type).orElse(null);
 
             for (Entry<String, Object> entry : sort.entrySet()) {
                 Object value = entry.getValue();


### PR DESCRIPTION
Profiling point queries using

```java
var entity = ds.find(Entity.class).filter(eq("id", id)).first();
```

shows that ~10 % of CPU time is spent throwing `NotMappableException` when the filter is being mapped to `org.bson.Document`. This patch should reduce the overhead.

Flame graph of point query execution, highlighting the stack traces which contain `new NotMappableException(type)`:
<img width="3840" height="2160" alt="new-not-mappable-exception" src="https://github.com/user-attachments/assets/d460618b-2011-4517-971e-bbb51a8912b8" />
