### PR TITLE
Rework custom ClassLoader support (based on #4159)

### DIFF
--- a/core/src/main/java/dev/morphia/Datastore.java
+++ b/core/src/main/java/dev/morphia/Datastore.java
@@ -635,11 +635,6 @@ public interface Datastore {
     @MorphiaInternal
     Mapper getMapper();
 
-    @MorphiaInternal
-    default ClassLoader getClassLoader() {
-        return getMapper().getClassLoader();
-    }
-
     /**
      * @param transaction the transaction wrapper
      * @param <T>         the return type

--- a/core/src/main/java/dev/morphia/Morphia.java
+++ b/core/src/main/java/dev/morphia/Morphia.java
@@ -89,16 +89,4 @@ public final class Morphia {
         return new DatastoreImpl(mongoClient, config);
     }
 
-    /**
-     * Creates a Datastore configured via config file
-     *
-     * @param mongoClient the client to use
-     * @param config      the configuration to use
-     * @param classLoader the classloader to use when scanning for entities and codecs. If null, the default classloader will be used.
-     * @return a Datastore that you can use to interact with MongoDB
-     * @since 3.0.0
-     */
-    public static Datastore createDatastore(MongoClient mongoClient, MorphiaConfig config, ClassLoader classLoader) {
-        return new DatastoreImpl(mongoClient, config, classLoader);
-    }
 }

--- a/core/src/main/java/dev/morphia/aggregation/AggregationImpl.java
+++ b/core/src/main/java/dev/morphia/aggregation/AggregationImpl.java
@@ -403,7 +403,7 @@ public class AggregationImpl<T> implements Aggregation<T> {
 
         private R map(Document next) {
             next.remove(discriminator);
-            return codec.decode(new DocumentReader(next, datastore.getClassLoader()), DecoderContext.builder().build());
+            return codec.decode(new DocumentReader(next, datastore.getConversions()), DecoderContext.builder().build());
         }
     }
 

--- a/core/src/main/java/dev/morphia/config/ManualMorphiaConfig.java
+++ b/core/src/main/java/dev/morphia/config/ManualMorphiaConfig.java
@@ -48,6 +48,7 @@ public class ManualMorphiaConfig implements MorphiaConfig {
     Boolean storeEmpties;
     Boolean storeNulls;
     UuidRepresentation uuidRepresentation;
+    ClassLoader classLoader;
 
     /**
      * @hidden
@@ -78,6 +79,7 @@ public class ManualMorphiaConfig implements MorphiaConfig {
         storeEmpties = base.storeEmpties();
         storeNulls = base.storeNulls();
         uuidRepresentation = base.uuidRepresentation();
+        classLoader = base.classLoader();
     }
 
     /**
@@ -93,6 +95,11 @@ public class ManualMorphiaConfig implements MorphiaConfig {
      */
     public static ManualMorphiaConfig configure(MorphiaConfig base) {
         return new ManualMorphiaConfig(base);
+    }
+
+    @Override
+    public ClassLoader classLoader() {
+        return orDefault(classLoader, Thread.currentThread().getContextClassLoader());
     }
 
     @Override

--- a/core/src/main/java/dev/morphia/config/MorphiaConfig.java
+++ b/core/src/main/java/dev/morphia/config/MorphiaConfig.java
@@ -88,15 +88,39 @@ public interface MorphiaConfig {
         List<ConfigSource> configSources = classPathSources(path, classLoader);
         if (configSources.isEmpty()) {
             LoggerFactory.getLogger(MorphiaConfig.class).warn(Sofia.missingConfigFile(path));
-            return new ManualMorphiaConfig();
+            return new ManualMorphiaConfig().classLoader(classLoader);
         }
-        return new SmallRyeConfigBuilder()
+        MorphiaConfig config = new SmallRyeConfigBuilder()
                 .addDefaultInterceptors()
                 .withMapping(MorphiaConfig.class)
                 .withSources(configSources)
                 .addDefaultSources()
                 .build()
                 .getConfigMapping(MorphiaConfig.class);
+        return config.classLoader(classLoader);
+    }
+
+    /**
+     * The ClassLoader to use for class resolution. Defaults to the current thread's context ClassLoader.
+     *
+     * @return the ClassLoader
+     * @since 2.5
+     */
+    default ClassLoader classLoader() {
+        return currentThread().getContextClassLoader();
+    }
+
+    /**
+     * Updates this configuration with a new ClassLoader and returns a new instance. The original instance is unchanged.
+     *
+     * @param value the new ClassLoader
+     * @return a new instance with the updated configuration
+     * @since 2.5
+     */
+    default MorphiaConfig classLoader(ClassLoader value) {
+        var newConfig = new ManualMorphiaConfig(this);
+        newConfig.classLoader = value;
+        return newConfig;
     }
 
     /**

--- a/core/src/main/java/dev/morphia/mapping/InstanceCreatorFactory.java
+++ b/core/src/main/java/dev/morphia/mapping/InstanceCreatorFactory.java
@@ -1,5 +1,6 @@
 package dev.morphia.mapping;
 
+import dev.morphia.mapping.codec.Conversions;
 import dev.morphia.mapping.codec.MorphiaInstanceCreator;
 
 /**
@@ -8,7 +9,8 @@ import dev.morphia.mapping.codec.MorphiaInstanceCreator;
 public interface InstanceCreatorFactory {
 
     /**
+     * @param conversions the Conversions instance to use
      * @return a new ClassAccessor instance
      */
-    MorphiaInstanceCreator create();
+    MorphiaInstanceCreator create(Conversions conversions);
 }

--- a/core/src/main/java/dev/morphia/mapping/codec/ArrayFieldAccessor.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/ArrayFieldAccessor.java
@@ -20,19 +20,20 @@ public class ArrayFieldAccessor extends FieldAccessor {
 
     private final TypeData<?> typeData;
     private final Class<?> componentType;
-    private final ClassLoader classLoader;
+    private final Conversions conversions;
 
     /**
      * Creates the accessor
      *
-     * @param typeData the type data
-     * @param field    the field
+     * @param typeData    the type data
+     * @param field       the field
+     * @param conversions the Conversions instance to use
      */
-    public ArrayFieldAccessor(TypeData<?> typeData, Field field, ClassLoader classLoader) {
+    public ArrayFieldAccessor(TypeData<?> typeData, Field field, Conversions conversions) {
         super(field);
         this.typeData = typeData;
         componentType = field.getType().getComponentType();
-        this.classLoader = classLoader;
+        this.conversions = conversions;
     }
 
     @Override
@@ -86,6 +87,6 @@ public class ArrayFieldAccessor extends FieldAccessor {
 
             return newArray;
         }
-        return Conversions.convert(o, type, classLoader);
+        return conversions.convert(o, type);
     }
 }

--- a/core/src/main/java/dev/morphia/mapping/codec/ClassCodec.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/ClassCodec.java
@@ -1,6 +1,5 @@
 package dev.morphia.mapping.codec;
 
-import dev.morphia.Datastore;
 import dev.morphia.mapping.MappingException;
 
 import org.bson.BsonReader;
@@ -13,17 +12,16 @@ import org.bson.codecs.EncoderContext;
  * Defines a codec for Class references
  */
 public class ClassCodec implements Codec<Class> {
-    private final Datastore datastore;
+    private final Conversions conversions;
 
-    public ClassCodec(Datastore datastore) {
-        this.datastore = datastore;
+    public ClassCodec(Conversions conversions) {
+        this.conversions = conversions;
     }
 
     @Override
     public Class decode(BsonReader reader, DecoderContext decoderContext) {
         try {
-            ClassLoader classLoader = datastore.getClassLoader();
-            return Class.forName(reader.readString(), true, classLoader);
+            return Class.forName(reader.readString(), true, conversions.getClassLoader());
         } catch (ClassNotFoundException e) {
             throw new MappingException(e.getMessage(), e);
         }

--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaCodecProvider.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaCodecProvider.java
@@ -36,6 +36,7 @@ import org.bson.codecs.pojo.PropertyCodecProvider;
 public class MorphiaCodecProvider implements CodecProvider {
     private final Map<Class<?>, Codec<?>> codecs = new HashMap<>();
     private final Mapper mapper;
+    private final Conversions conversions;
     private final List<PropertyCodecProvider> propertyCodecProviders = new ArrayList<>();
     private Datastore datastore;
 
@@ -47,6 +48,7 @@ public class MorphiaCodecProvider implements CodecProvider {
     public MorphiaCodecProvider(Datastore datastore) {
         this.datastore = datastore;
         this.mapper = datastore.getMapper();
+        this.conversions = mapper.getConversions();
 
         // Load user-provided custom codecs first, to prevent the defaults from overriding them.
         ServiceLoader<MorphiaPropertyCodecProvider> providers = ServiceLoader.load(MorphiaPropertyCodecProvider.class);
@@ -54,7 +56,7 @@ public class MorphiaCodecProvider implements CodecProvider {
             propertyCodecProviders.add(provider);
         });
 
-        propertyCodecProviders.addAll(List.of(new MorphiaMapPropertyCodecProvider(datastore),
+        propertyCodecProviders.addAll(List.of(new MorphiaMapPropertyCodecProvider(datastore, conversions),
                 new MorphiaCollectionPropertyCodecProvider()));
     }
 
@@ -73,7 +75,7 @@ public class MorphiaCodecProvider implements CodecProvider {
         MorphiaCodec<T> codec = (MorphiaCodec<T>) codecs.get(type);
         if (codec == null && (mapper.isMapped(type) || mapper.isMappable(type))) {
             EntityModel model = mapper.getEntityModel(type);
-            codec = new MorphiaCodec<>(datastore, model, propertyCodecProviders, mapper.getDiscriminatorLookup(), registry);
+            codec = new MorphiaCodec<>(datastore, model, propertyCodecProviders, mapper.getDiscriminatorLookup(), registry, conversions);
             if (model.hasLifecycle(PostPersist.class) || model.hasLifecycle(PrePersist.class) || mapper.hasInterceptors()) {
                 codec.setEncoder(new LifecycleEncoder(codec));
             }
@@ -97,7 +99,7 @@ public class MorphiaCodecProvider implements CodecProvider {
     @Nullable
     public <T> Codec<T> getRefreshCodec(T entity, CodecRegistry registry) {
         EntityModel model = mapper.getEntityModel(entity.getClass());
-        return new MorphiaCodec<>(datastore, model, propertyCodecProviders, mapper.getDiscriminatorLookup(), registry) {
+        return new MorphiaCodec<>(datastore, model, propertyCodecProviders, mapper.getDiscriminatorLookup(), registry, conversions) {
             @Override
             protected EntityDecoder<T> getDecoder() {
                 return new EntityDecoder<>(this) {

--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapCodec.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapCodec.java
@@ -34,11 +34,13 @@ public class MorphiaMapCodec implements Codec<Map> {
     private Supplier<Map> factory;
 
     private Datastore datastore;
+    private final Conversions conversions;
 
     private final Codec<?> valueCodec;
 
-    public MorphiaMapCodec(DatastoreImpl datastore, Class<?> clazz, Codec<?> valueCodec) {
+    public MorphiaMapCodec(DatastoreImpl datastore, Class<?> clazz, Codec<?> valueCodec, Conversions conversions) {
         this.datastore = datastore;
+        this.conversions = conversions;
         this.valueCodec = valueCodec;
         try {
             Constructor<?> ctor = clazz.getDeclaredConstructor();
@@ -78,7 +80,7 @@ public class MorphiaMapCodec implements Codec<Map> {
         document(writer, () -> {
             for (Entry<?, ?> entry : ((Map<?, ?>) map).entrySet()) {
                 final Object key = entry.getKey();
-                writer.writeName(Conversions.convert(key, String.class, datastore.getClassLoader()));
+                writer.writeName(conversions.convert(key, String.class));
                 if (entry.getValue() == null) {
                     writer.writeNull();
                 } else {

--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapCodecProvider.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapCodecProvider.java
@@ -32,7 +32,7 @@ public class MorphiaMapCodecProvider implements CodecProvider {
             return (Codec<T>) new BsonDocumentCodec(registry);
         } else if (Map.class.isAssignableFrom(clazz) && !Document.class.isAssignableFrom(clazz)) {
             Class valueType = typeArguments.size() == 2 ? (Class) typeArguments.get(1) : Object.class;
-            return (Codec<T>) new MorphiaMapCodec(datastore, clazz, registry.get(valueType));
+            return (Codec<T>) new MorphiaMapCodec(datastore, clazz, registry.get(valueType), datastore.getConversions());
         }
         return null;
     }

--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapPropertyCodecProvider.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaMapPropertyCodecProvider.java
@@ -30,9 +30,11 @@ import static dev.morphia.aggregation.codecs.ExpressionHelper.document;
 @SuppressWarnings("unchecked")
 class MorphiaMapPropertyCodecProvider extends MorphiaPropertyCodecProvider {
     private final Datastore datastore;
+    private final Conversions conversions;
 
-    public MorphiaMapPropertyCodecProvider(Datastore datastore) {
+    public MorphiaMapPropertyCodecProvider(Datastore datastore, Conversions conversions) {
         this.datastore = datastore;
+        this.conversions = conversions;
     }
 
     @Override
@@ -74,7 +76,7 @@ class MorphiaMapPropertyCodecProvider extends MorphiaPropertyCodecProvider {
             document(writer, () -> {
                 for (Entry<K, V> entry : map.entrySet()) {
                     final K key = entry.getKey();
-                    writer.writeName(Conversions.convert(key, String.class, datastore.getClassLoader()));
+                    writer.writeName(conversions.convert(key, String.class));
                     if (entry.getValue() == null) {
                         writer.writeNull();
                     } else {
@@ -89,7 +91,7 @@ class MorphiaMapPropertyCodecProvider extends MorphiaPropertyCodecProvider {
             reader.readStartDocument();
             Map<K, V> map = getInstance();
             while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
-                final K key = Conversions.convert(reader.readName(), keyType, datastore.getClassLoader());
+                final K key = conversions.convert(reader.readName(), keyType);
                 if (reader.getCurrentBsonType() == BsonType.NULL) {
                     map.put(key, null);
                     reader.readNull();

--- a/core/src/main/java/dev/morphia/mapping/codec/MorphiaTypesCodecProvider.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/MorphiaTypesCodecProvider.java
@@ -28,7 +28,7 @@ public class MorphiaTypesCodecProvider implements CodecProvider {
         addCodec(new MorphiaDateCodec(datastore));
         addCodec(new MorphiaLocalDateTimeCodec(datastore));
         addCodec(new MorphiaLocalTimeCodec());
-        addCodec(new ClassCodec(datastore));
+        addCodec(new ClassCodec(datastore.getConversions()));
         addCodec(new CenterCodec());
         addCodec(new KeyCodec(datastore));
         addCodec(new LocaleCodec());

--- a/core/src/main/java/dev/morphia/mapping/codec/pojo/EntityDecoder.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/pojo/EntityDecoder.java
@@ -18,7 +18,6 @@ import org.bson.codecs.configuration.CodecRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static dev.morphia.mapping.codec.Conversions.convert;
 import static java.lang.String.format;
 
 /**
@@ -71,7 +70,7 @@ public class EntityDecoder<T> implements Decoder<T> {
             } catch (BsonInvalidOperationException e) {
                 mark.reset();
                 final Object value = morphiaCodec.getDatastore().getCodecRegistry().get(Object.class).decode(reader, decoderContext);
-                instanceCreator.set(convert(value, model.getTypeData().getType(), morphiaCodec.getDatastore().getClassLoader()), model);
+                instanceCreator.set(morphiaCodec.getConversions().convert(value, model.getTypeData().getType()), model);
             }
         } else {
             reader.skipValue();
@@ -118,7 +117,7 @@ public class EntityDecoder<T> implements Decoder<T> {
     }
 
     protected MorphiaInstanceCreator getInstanceCreator() {
-        return classModel.getInstanceCreator();
+        return classModel.getInstanceCreator(morphiaCodec.getConversions());
     }
 
     protected MorphiaCodec<T> getMorphiaCodec() {

--- a/core/src/main/java/dev/morphia/mapping/codec/pojo/EntityModel.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/pojo/EntityModel.java
@@ -28,6 +28,7 @@ import dev.morphia.annotations.internal.MorphiaInternal;
 import dev.morphia.mapping.InstanceCreatorFactory;
 import dev.morphia.mapping.InstanceCreatorFactoryImpl;
 import dev.morphia.mapping.MappingException;
+import dev.morphia.mapping.codec.Conversions;
 import dev.morphia.mapping.codec.MorphiaInstanceCreator;
 import dev.morphia.mapping.lifecycle.EntityListenerAdapter;
 import dev.morphia.mapping.lifecycle.OnEntityListenerAdapter;
@@ -71,7 +72,6 @@ public class EntityModel {
     private final PropertyModel idProperty;
     private final PropertyModel versionProperty;
     private final List<EntityListener<?>> listeners = new ArrayList<>();
-    private final ClassLoader classLoader;
 
     /**
      * Creates a new instance
@@ -138,7 +138,6 @@ public class EntityModel {
         }
 
         listeners.add(new OnEntityListenerAdapter(getType()));
-        this.classLoader = builder.mapper().getClassLoader();
     }
 
     public EntityModel(EntityModel other) {
@@ -195,7 +194,6 @@ public class EntityModel {
         }
 
         listeners.add(new OnEntityListenerAdapter(getType()));
-        this.classLoader = other.classLoader;
     }
 
     /**
@@ -287,10 +285,11 @@ public class EntityModel {
     }
 
     /**
+     * @param conversions the Conversions instance to use
      * @return a new InstanceCreator instance for the ClassModel
      */
-    public MorphiaInstanceCreator getInstanceCreator() {
-        return creatorFactory.create();
+    public MorphiaInstanceCreator getInstanceCreator(Conversions conversions) {
+        return creatorFactory.create(conversions);
     }
 
     /**
@@ -380,10 +379,6 @@ public class EntityModel {
     public boolean hasLifecycle(Class<? extends Annotation> type) {
         return listeners.stream()
                 .anyMatch(listener -> listener.hasAnnotation(type));
-    }
-
-    public ClassLoader getClassLoader() {
-        return classLoader;
     }
 
     @Override

--- a/core/src/main/java/dev/morphia/mapping/codec/pojo/EntityModelBuilder.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/pojo/EntityModelBuilder.java
@@ -330,10 +330,6 @@ public class EntityModelBuilder {
         return type;
     }
 
-    public Mapper mapper() {
-        return mapper;
-    }
-
     /**
      * @return the name of the version property
      */

--- a/core/src/main/java/dev/morphia/mapping/codec/pojo/LifecycleDecoder.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/pojo/LifecycleDecoder.java
@@ -48,11 +48,11 @@ public class LifecycleDecoder<T> extends EntityDecoder<T> {
                 }
             }
         }
-        final MorphiaInstanceCreator instanceCreator = model.getInstanceCreator();
+        final MorphiaInstanceCreator instanceCreator = model.getInstanceCreator(getMorphiaCodec().getConversions());
         T entity = (T) instanceCreator.getInstance();
 
         model.callLifecycleMethods(PreLoad.class, entity, document, getMorphiaCodec().getDatastore());
-        decodeProperties(new DocumentReader(document, model.getClassLoader()), decoderContext, instanceCreator,
+        decodeProperties(new DocumentReader(document, getMorphiaCodec().getConversions()), decoderContext, instanceCreator,
                 model);
         model.callLifecycleMethods(PostLoad.class, entity, document, getMorphiaCodec().getDatastore());
 

--- a/core/src/main/java/dev/morphia/mapping/codec/pojo/MorphiaCodec.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/pojo/MorphiaCodec.java
@@ -7,6 +7,7 @@ import dev.morphia.annotations.internal.MorphiaInternal;
 import dev.morphia.mapping.DiscriminatorLookup;
 import dev.morphia.mapping.Mapper;
 import dev.morphia.mapping.MappingException;
+import dev.morphia.mapping.codec.Conversions;
 import dev.morphia.mapping.codec.PropertyCodecRegistryImpl;
 import dev.morphia.sofia.Sofia;
 
@@ -24,7 +25,6 @@ import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static dev.morphia.mapping.codec.Conversions.convert;
 import static org.bson.codecs.configuration.CodecRegistries.fromCodecs;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 
@@ -45,6 +45,7 @@ public class MorphiaCodec<T> implements CollectibleCodec<T> {
     private final CodecRegistry registry;
     private final PropertyCodecRegistry propertyCodecRegistry;
     private final DiscriminatorLookup discriminatorLookup;
+    private final Conversions conversions;
     private EntityEncoder<T> encoder;
     private EntityDecoder<T> decoder;
     private Datastore datastore;
@@ -60,9 +61,11 @@ public class MorphiaCodec<T> implements CollectibleCodec<T> {
      */
     public MorphiaCodec(Datastore datastore, EntityModel model,
             List<PropertyCodecProvider> propertyCodecProviders,
-            DiscriminatorLookup discriminatorLookup, CodecRegistry registry) {
+            DiscriminatorLookup discriminatorLookup, CodecRegistry registry,
+            Conversions conversions) {
         this.datastore = datastore;
         this.discriminatorLookup = discriminatorLookup;
+        this.conversions = conversions;
 
         this.entityModel = model;
         this.registry = fromRegistries(fromCodecs(this), registry);
@@ -91,7 +94,7 @@ public class MorphiaCodec<T> implements CollectibleCodec<T> {
         if (!documentHasId(entity)) {
             if (idProperty != null) {
                 if (ObjectId.class.equals(idProperty.getType()) || String.class.equals(idProperty.getType())) {
-                    idProperty.setValue(entity, convert(new ObjectId(), idProperty.getType(), datastore.getClassLoader()));
+                    idProperty.setValue(entity, conversions.convert(new ObjectId(), idProperty.getType()));
                 } else {
                     LOG.warn(Sofia.noIdAndNotObjectId(entity.getClass().getName()));
                 }
@@ -111,6 +114,13 @@ public class MorphiaCodec<T> implements CollectibleCodec<T> {
     @Override
     public BsonValue getDocumentId(Object document) {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return the Conversions instance
+     */
+    public Conversions getConversions() {
+        return conversions;
     }
 
     /**

--- a/core/src/main/java/dev/morphia/mapping/codec/pojo/PropertyModel.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/pojo/PropertyModel.java
@@ -70,11 +70,13 @@ public final class PropertyModel {
     private final Map<Class<? extends Annotation>, Annotation> annotationMap = new HashMap<>();
     private final List<String> loadNames; // List of stored names in order of trying, contains nameToStore and potential aliases
     private final EntityModel entityModel;
+    private final Conversions conversions;
     private Codec<? super Object> codec;
     private Class<?> normalizedType;
 
     PropertyModel(PropertyModelBuilder builder) {
         entityModel = builder.owner();
+        conversions = builder.conversions();
         name = Objects.requireNonNull(builder.name(), Sofia.notNull("name"));
         mappedName = Objects.requireNonNull(builder.mappedName(), Sofia.notNull("name"));
         typeData = Objects.requireNonNull(builder.typeData(), Sofia.notNull("typeData"));
@@ -97,6 +99,7 @@ public final class PropertyModel {
 
     public PropertyModel(EntityModel owner, PropertyModel other) {
         entityModel = owner;
+        conversions = other.conversions;
 
         name = other.name;
         typeData = other.typeData;
@@ -362,7 +365,7 @@ public final class PropertyModel {
      * @param value    the value to set
      */
     public void setValue(Object instance, @Nullable Object value) {
-        accessor.set(instance, Conversions.convert(value, getType(), entityModel.getClassLoader()));
+        accessor.set(instance, conversions.convert(value, getType()));
     }
 
     /**

--- a/core/src/main/java/dev/morphia/mapping/codec/pojo/PropertyModelBuilder.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/pojo/PropertyModelBuilder.java
@@ -30,6 +30,7 @@ import dev.morphia.annotations.Version;
 import dev.morphia.annotations.internal.MorphiaInternal;
 import dev.morphia.config.MorphiaConfig;
 import dev.morphia.mapping.Mapper;
+import dev.morphia.mapping.codec.Conversions;
 import dev.morphia.mapping.codec.MorphiaPropertySerialization;
 
 import org.bson.codecs.pojo.PropertyAccessor;
@@ -309,6 +310,13 @@ public final class PropertyModelBuilder {
                 .add("typeData=" + typeData)
                 .add("annotations=" + annotations)
                 .toString();
+    }
+
+    /**
+     * @return the Conversions instance from the mapper
+     */
+    Conversions conversions() {
+        return mapper.getConversions();
     }
 
     /**

--- a/core/src/main/java/dev/morphia/mapping/codec/reader/DocumentReader.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/reader/DocumentReader.java
@@ -48,18 +48,19 @@ public class DocumentReader implements BsonReader {
         }
     };
     private final ReaderState start;
-    private final ClassLoader classLoader;
+    private final Conversions conversions;
     private ReaderState current;
 
     /**
      * Construct a new instance.
      *
-     * @param document the document to read from
+     * @param document    the document to read from
+     * @param conversions the Conversions instance to use
      */
-    public DocumentReader(Document document, ClassLoader classLoader) {
+    public DocumentReader(Document document, Conversions conversions) {
         current = new DocumentState(this, document);
         start = current;
-        this.classLoader = classLoader;
+        this.conversions = conversions;
     }
 
     /**
@@ -149,7 +150,7 @@ public class DocumentReader implements BsonReader {
 
     @Override
     public long readDateTime() {
-        Long value = Conversions.convert(stage().value(), long.class, classLoader);
+        Long value = conversions.convert(stage().value(), long.class);
         if (value != null) {
             return value;
         }

--- a/core/src/main/java/dev/morphia/mapping/codec/references/ReferenceCodec.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/references/ReferenceCodec.java
@@ -24,7 +24,6 @@ import dev.morphia.annotations.internal.MorphiaInternal;
 import dev.morphia.mapping.Mapper;
 import dev.morphia.mapping.MappingException;
 import dev.morphia.mapping.codec.BaseReferenceCodec;
-import dev.morphia.mapping.codec.Conversions;
 import dev.morphia.mapping.codec.pojo.EntityModel;
 import dev.morphia.mapping.codec.pojo.PropertyHandler;
 import dev.morphia.mapping.codec.pojo.PropertyModel;
@@ -164,7 +163,7 @@ public class ReferenceCodec extends BaseReferenceCodec<Object> implements Proper
                 try {
                     id = datastore.getCodecRegistry()
                             .get(datastore.getMapper().getClass(document))
-                            .decode(new DocumentReader(document, datastore.getClassLoader()), decoderContext);
+                            .decode(new DocumentReader(document, datastore.getMapper().getConversions()), decoderContext);
                 } catch (CodecConfigurationException e) {
                     throw new MappingException(Sofia.cannotFindTypeInDocument(), e);
                 }
@@ -176,7 +175,7 @@ public class ReferenceCodec extends BaseReferenceCodec<Object> implements Proper
             if (refId instanceof Document) {
                 refId = datastore.getCodecRegistry()
                         .get(Object.class)
-                        .decode(new DocumentReader((Document) refId, datastore.getClassLoader()), decoderContext);
+                        .decode(new DocumentReader((Document) refId, datastore.getMapper().getConversions()), decoderContext);
             }
             id = new DBRef(ref.getDatabaseName(), ref.getCollectionName(), refId);
         }
@@ -374,13 +373,13 @@ public class ReferenceCodec extends BaseReferenceCodec<Object> implements Proper
         Codec<?> codec = getDatastore().getCodecRegistry().get(getEntityModelForField().getType());
         return value.stream()
                 .filter(v -> v instanceof Document && ((Document) v).containsKey("_id"))
-                .map(d -> codec.decode(new DocumentReader((Document) d, datastore.getClassLoader()), DecoderContext.builder().build()))
+                .map(d -> codec.decode(new DocumentReader((Document) d, mapper.getConversions()), DecoderContext.builder().build()))
                 .collect(Collectors.toList());
     }
 
     MorphiaReference<?> readDocument(Document value) {
         final Object id = getDatastore().getCodecRegistry().get(Object.class)
-                .decode(new DocumentReader(value, datastore.getClassLoader()), DecoderContext.builder().build());
+                .decode(new DocumentReader(value, mapper.getConversions()), DecoderContext.builder().build());
         return readSingle(id);
     }
 
@@ -395,7 +394,7 @@ public class ReferenceCodec extends BaseReferenceCodec<Object> implements Proper
         final Map<Object, Object> ids = new LinkedHashMap<>();
         Class<?> keyType = getTypeData().getTypeParameters().get(0).getType();
         for (Entry<Object, Object> entry : value.entrySet()) {
-            ids.put(Conversions.convert(entry.getKey(), keyType, mapper.getClassLoader()), entry.getValue());
+            ids.put(mapper.getConversions().convert(entry.getKey(), keyType), entry.getValue());
         }
 
         return new MapReference(datastore, ids, getEntityModelForField());

--- a/core/src/main/java/dev/morphia/mapping/conventions/FieldDiscovery.java
+++ b/core/src/main/java/dev/morphia/mapping/conventions/FieldDiscovery.java
@@ -10,6 +10,7 @@ import dev.morphia.annotations.internal.MorphiaInternal;
 import dev.morphia.mapping.Mapper;
 import dev.morphia.mapping.MappingException;
 import dev.morphia.mapping.codec.ArrayFieldAccessor;
+import dev.morphia.mapping.codec.Conversions;
 import dev.morphia.mapping.codec.FieldAccessor;
 import dev.morphia.mapping.codec.pojo.EntityModelBuilder;
 import dev.morphia.mapping.codec.pojo.TypeData;
@@ -35,7 +36,7 @@ public class FieldDiscovery implements MorphiaConvention {
                                 .name(field.getName())
                                 .typeData(typeData)
                                 .annotations(List.of(field.getDeclaredAnnotations()))
-                                .accessor(getAccessor(getTargetField(builder, field), typeData, mapper.getClassLoader()))
+                                .accessor(getAccessor(getTargetField(builder, field), typeData, mapper.getConversions()))
                                 .modifiers(field.getModifiers())
                                 .discoverMappedName();
                     } catch (NoSuchFieldException e) {
@@ -55,9 +56,9 @@ public class FieldDiscovery implements MorphiaConvention {
         return builder.targetType().getDeclaredField(field.getName());
     }
 
-    private PropertyAccessor<? super Object> getAccessor(Field field, TypeData<?> typeData, ClassLoader classLoader) {
+    private PropertyAccessor<? super Object> getAccessor(Field field, TypeData<?> typeData, Conversions conversions) {
         return field.getType().isArray() && !field.getType().getComponentType().equals(byte.class)
-                ? new ArrayFieldAccessor(typeData, field, classLoader)
+                ? new ArrayFieldAccessor(typeData, field, conversions)
                 : new FieldAccessor(field);
     }
 }

--- a/core/src/main/java/dev/morphia/mapping/internal/ConstructorCreator.java
+++ b/core/src/main/java/dev/morphia/mapping/internal/ConstructorCreator.java
@@ -50,9 +50,10 @@ public class ConstructorCreator implements MorphiaInstanceCreator {
     /**
      * @param model       the model
      * @param constructor the constructor to use
+     * @param conversions the Conversions instance to use
      */
     @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public ConstructorCreator(EntityModel model, Constructor<?> constructor) {
+    public ConstructorCreator(EntityModel model, Constructor<?> constructor, Conversions conversions) {
         this.model = model;
         this.constructor = constructor;
         this.constructor.setAccessible(true);
@@ -68,7 +69,7 @@ public class ConstructorCreator implements MorphiaInstanceCreator {
                 throw new MappingException(Sofia.unnamedConstructorParameter(model.getType().getName()));
             }
             BiFunction<Object[], Object, Void> old = positions.put(name, (Object[] params, Object v) -> {
-                params[finalI] = Conversions.convert(v, parameter.getType(), model.getClassLoader());
+                params[finalI] = conversions.convert(v, parameter.getType());
                 return null;
             });
 

--- a/core/src/main/java/dev/morphia/query/internal/MorphiaKeyCursor.java
+++ b/core/src/main/java/dev/morphia/query/internal/MorphiaKeyCursor.java
@@ -117,7 +117,7 @@ public class MorphiaKeyCursor<T> implements MongoCursor<Key<T>> {
             aClass = mapper.getClass(document);
         }
 
-        DocumentReader reader = new DocumentReader(document, datastore.getClassLoader());
+        DocumentReader reader = new DocumentReader(document, datastore.getMapper().getConversions());
 
         return datastore.getCodecRegistry()
                 .get(aClass)

--- a/core/src/test/java/dev/morphia/test/TemplatedTestBase.java
+++ b/core/src/test/java/dev/morphia/test/TemplatedTestBase.java
@@ -221,7 +221,7 @@ public abstract class TemplatedTestBase extends TestBase {
 
         DecoderContext context = DecoderContext.builder().build();
         return documents.stream()
-                .map(document -> codec.decode(new DocumentReader(document, getMapper().getClassLoader()), context))
+                .map(document -> (D) codec.decode(new DocumentReader(document, getMapper().getConversions()), context))
                 .collect(toList());
     }
 }

--- a/core/src/test/java/dev/morphia/test/TestBase.java
+++ b/core/src/test/java/dev/morphia/test/TestBase.java
@@ -192,7 +192,7 @@ public abstract class TestBase extends MorphiaTestSetup {
             aClass = mapper.getClass(document);
         }
 
-        DocumentReader reader = new DocumentReader(document, mapper.getClassLoader());
+        DocumentReader reader = new DocumentReader(document, mapper.getConversions());
 
         return getDs().getCodecRegistry()
                 .get(aClass)

--- a/core/src/test/java/dev/morphia/test/mapping/codec/DocumentReaderTest.java
+++ b/core/src/test/java/dev/morphia/test/mapping/codec/DocumentReaderTest.java
@@ -93,7 +93,7 @@ public class DocumentReaderTest extends TestBase {
         Document first = collection.find().first();
 
         Parent decode = getDs().getCodecRegistry().get(Parent.class)
-                .decode(new DocumentReader(first, getMapper().getClassLoader()), DecoderContext.builder().build());
+                .decode(new DocumentReader(first, getMapper().getConversions()), DecoderContext.builder().build());
 
         assertEquals(parent, decode);
     }
@@ -280,7 +280,7 @@ public class DocumentReaderTest extends TestBase {
     }
 
     private void setup(Document document) {
-        reader = new DocumentReader(document, getMapper().getClassLoader());
+        reader = new DocumentReader(document, getMapper().getConversions());
     }
 
     private void step(Consumer<BsonReader> function) {

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -6,5 +6,5 @@ nav:
 - "modules/ROOT/nav.adoc"
 asciidoc:
   attributes:
-    version: "2.5.1"
-    srcRef: "https://github.com/MorphiaOrg/morphia/tree/2.5.x"
+    version: "2.5.2"
+    srcRef: "https://github.com/MorphiaOrg/morphia/blob/master"

--- a/docs/modules/ROOT/examples/complete-morphia-config.properties
+++ b/docs/modules/ROOT/examples/complete-morphia-config.properties
@@ -15,6 +15,10 @@ morphia.apply-indexes=false
 ######
 morphia.auto-import-models=false
 ######
+# Required
+######
+morphia.class-loader=jdk.internal.loader.ClassLoaders$AppClassLoader
+######
 # Optional
 ######
 morphia.codec-provider=

--- a/docs/modules/ROOT/examples/legacy-morphia-config.properties
+++ b/docs/modules/ROOT/examples/legacy-morphia-config.properties
@@ -3,6 +3,10 @@
 ######
 morphia.auto-import-models=false
 ######
+# Required
+######
+morphia.class-loader=jdk.internal.loader.ClassLoaders$AppClassLoader
+######
 # default=camelCase
 # possible values=camelCase, identity, kebabCase, lowerCase, snakeCase, fqcn
 ######

--- a/docs/modules/ROOT/examples/minimal-morphia-config.properties
+++ b/docs/modules/ROOT/examples/minimal-morphia-config.properties
@@ -2,3 +2,7 @@
 # default=true
 ######
 morphia.auto-import-models=false
+######
+# Required
+######
+morphia.class-loader=jdk.internal.loader.ClassLoaders$AppClassLoader


### PR DESCRIPTION
## Summary
- Reworks the custom ClassLoader approach from #4159 to properly thread `Conversions` through the codec chain
- Moves `Conversions` ownership from `Mapper` to `DatastoreImpl`, passing it explicitly to `MorphiaCodec`, `PropertyModel`, and `InstanceCreatorFactory`
- Adds `classLoader` config property to `MorphiaConfig` with `ManualMorphiaConfig` support
- Removes unnecessary `getClassLoader()` from `Datastore` interface and extra `Morphia.createDatastore()` overloads in favor of config-based approach

## Test plan
- [ ] Verify all 965 core tests pass
- [ ] Verify custom ClassLoader is properly used for class resolution throughout the codec pipeline
- [ ] Verify backward compatibility (default ClassLoader = thread context ClassLoader)

Supersedes #4159

🤖 Generated with [Claude Code](https://claude.com/claude-code)