### PR TITLE
Backport 2.5.x: Set codec registry once

### DIFF
--- a/core/src/main/java/dev/morphia/DatastoreImpl.java
+++ b/core/src/main/java/dev/morphia/DatastoreImpl.java
@@ -146,6 +146,7 @@ public class DatastoreImpl implements AdvancedDatastore {
         this.queryFactory = datastore.queryFactory;
         this.operations = datastore.operations;
         codecRegistry = buildRegistry();
+        this.database = this.database.withCodecRegistry(this.codecRegistry);
     }
 
     private CodecRegistry buildRegistry() {
@@ -345,8 +346,7 @@ public class DatastoreImpl implements AdvancedDatastore {
         EntityModel entityModel = mapper.getEntityModel(type);
         String collectionName = entityModel.getCollectionName();
 
-        MongoCollection<T> collection = getDatabase().getCollection(collectionName, type)
-                .withCodecRegistry(codecRegistry);
+        MongoCollection<T> collection = getDatabase().getCollection(collectionName, type);
 
         Entity annotation = entityModel.getEntityAnnotation();
         if (annotation != null && !annotation.concern().equals("")) {


### PR DESCRIPTION
This avoids effectively emptying the CodecCache every time `Datastore.find()` is being called.

Fixes #4180