### PR TITLE
Narrow critter integration tests to only copy models package

### DIFF
--- a/critter/critter-integration-tests/pom.xml
+++ b/critter/critter-integration-tests/pom.xml
@@ -61,7 +61,6 @@
 
     <build>
         <plugins>
-<!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -78,22 +77,9 @@
                             <resources>
                                 <resource>
                                     <directory>${maven.multiModuleProjectDirectory}/core/src/test/java</directory>
-                                    <filtering>false</filtering>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>copy-test-resources</id>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.basedir}/src/core-test/resources</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${maven.multiModuleProjectDirectory}/core/src/test/resources</directory>
+                                    <includes>
+                                        <include>dev/morphia/test/models/**</include>
+                                    </includes>
                                     <filtering>false</filtering>
                                 </resource>
                             </resources>
@@ -118,23 +104,8 @@
                             </sources>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>add-core-test-resources</id>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>add-test-resource</goal>
-                        </goals>
-                        <configuration>
-                            <resources>
-                                <resource>
-                                    <directory>${project.basedir}/src/core-test/resources</directory>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
--->
             <plugin>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>critter-maven</artifactId>


### PR DESCRIPTION
## Summary
- Restricts the `copy-test-sources` execution to only copy `dev/morphia/test/models/**` instead of the entire `core/src/test/java` tree
- Removes the `copy-test-resources` execution and its corresponding `add-core-test-resources` build-helper registration since they are no longer needed
- Re-enables the source copying that was previously commented out, now scoped to just models

## Test plan
- [ ] Verify `./mvnw test -pl :critter-integration-tests -Ddeploy.skip=true` compiles and runs successfully
- [ ] Confirm only model classes are copied to `src/core-test/java`
- [ ] Verify critter-maven generates the expected classes for the copied models

🤖 Generated with [Claude Code](https://claude.com/claude-code)