### PR TITLE
Phase 2: VarHandle accessor generator for runtime mapper mode

### DIFF
--- a/critter/core/src/main/kotlin/dev/morphia/critter/parser/gizmo/CritterGizmoGenerator.kt
+++ b/critter/core/src/main/kotlin/dev/morphia/critter/parser/gizmo/CritterGizmoGenerator.kt
@@ -14,6 +14,7 @@ object CritterGizmoGenerator {
     fun generate(
         type: Class<*>,
         critterClassLoader: CritterClassLoader = CritterClassLoader(),
+        runtimeMode: Boolean = false,
     ): GizmoEntityModelGenerator {
         val classNode = ClassNode()
         val resourceName = type.name.replace('.', '/') + ".class"
@@ -21,7 +22,7 @@ object CritterGizmoGenerator {
             type.classLoader.getResourceAsStream(resourceName)
                 ?: throw IllegalArgumentException("Could not find class file for ${type.name}")
         ClassReader(inputStream).accept(classNode, 0)
-        val propertyFinder = PropertyFinder(Generators.mapper, critterClassLoader)
+        val propertyFinder = PropertyFinder(Generators.mapper, critterClassLoader, runtimeMode)
 
         return entityModel(
             type,
@@ -42,6 +43,18 @@ object CritterGizmoGenerator {
 
     fun accessor(entityType: Class<*>, critterClassLoader: CritterClassLoader, method: MethodNode) =
         PropertyAccessorGenerator(entityType, critterClassLoader, method).emit()
+
+    fun varHandleAccessor(
+        entityType: Class<*>,
+        critterClassLoader: CritterClassLoader,
+        field: FieldNode,
+    ) = VarHandleAccessorGenerator(entityType, critterClassLoader, field).emit()
+
+    fun varHandleAccessor(
+        entityType: Class<*>,
+        critterClassLoader: CritterClassLoader,
+        method: MethodNode,
+    ) = VarHandleAccessorGenerator(entityType, critterClassLoader, method).emit()
 
     fun propertyModelGenerator(
         entityType: Class<*>,

--- a/critter/core/src/main/kotlin/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.kt
+++ b/critter/core/src/main/kotlin/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.kt
@@ -1,0 +1,416 @@
+package dev.morphia.critter.parser.gizmo
+
+import dev.morphia.critter.parser.getterToPropertyName
+import dev.morphia.critter.titleCase
+import io.quarkus.gizmo.FieldDescriptor
+import io.quarkus.gizmo.MethodDescriptor.ofConstructor
+import io.quarkus.gizmo.MethodDescriptor.ofMethod
+import io.quarkus.gizmo.SignatureBuilder.forClass
+import io.quarkus.gizmo.SignatureBuilder.forMethod
+import io.quarkus.gizmo.Type.classType
+import io.quarkus.gizmo.Type.parameterizedType
+import io.quarkus.gizmo.Type.typeVariable
+import io.quarkus.gizmo.Type.voidType
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodHandles.Lookup
+import java.lang.invoke.MethodType
+import java.lang.invoke.VarHandle
+import java.lang.reflect.Modifier
+import org.bson.codecs.pojo.PropertyAccessor
+import org.objectweb.asm.Type.getReturnType
+import org.objectweb.asm.Type.getType
+import org.objectweb.asm.tree.FieldNode
+import org.objectweb.asm.tree.MethodNode
+
+class VarHandleAccessorGenerator : BaseGizmoGenerator {
+    constructor(
+        entity: Class<*>,
+        critterClassLoader: dev.morphia.critter.CritterClassLoader,
+        field: FieldNode,
+    ) : super(entity, critterClassLoader) {
+        propertyName = field.name
+        propertyType = getType(field.desc).className
+        isFieldBased = true
+        getterName = null
+        setterName = null
+        generatedType = "${baseName}.${propertyName.titleCase()}Accessor"
+    }
+
+    constructor(
+        entity: Class<*>,
+        critterClassLoader: dev.morphia.critter.CritterClassLoader,
+        method: MethodNode,
+    ) : super(entity, critterClassLoader) {
+        propertyName = method.getterToPropertyName(entity)
+        propertyType = getReturnType(method.desc).className
+        isFieldBased = false
+        getterName = method.name
+        setterName = "set${propertyName.titleCase()}"
+        generatedType = "${baseName}.${propertyName.titleCase()}Accessor"
+    }
+
+    val propertyName: String
+    val propertyType: String
+    val isFieldBased: Boolean
+    val getterName: String?
+    val setterName: String?
+
+    val isPrimitive: Boolean
+        get() = primitiveToWrapper.containsKey(propertyType)
+
+    val wrapperType: String
+        get() = primitiveToWrapper[propertyType] ?: propertyType
+
+    private val hasSetter: Boolean by lazy {
+        if (isFieldBased || setterName == null) return@lazy false
+        val paramClass =
+            if (isPrimitive) primitiveClass(propertyType) else Class.forName(propertyType)
+        try {
+            entity.getDeclaredMethod(setterName!!, paramClass)
+            true
+        } catch (_: NoSuchMethodException) {
+            false
+        }
+    }
+
+    companion object {
+        private val primitiveToWrapper =
+            mapOf(
+                "boolean" to "java.lang.Boolean",
+                "byte" to "java.lang.Byte",
+                "char" to "java.lang.Character",
+                "short" to "java.lang.Short",
+                "int" to "java.lang.Integer",
+                "long" to "java.lang.Long",
+                "float" to "java.lang.Float",
+                "double" to "java.lang.Double",
+            )
+
+        private val primitiveClasses =
+            mapOf(
+                "boolean" to Boolean::class.javaPrimitiveType!!,
+                "byte" to Byte::class.javaPrimitiveType!!,
+                "char" to Char::class.javaPrimitiveType!!,
+                "short" to Short::class.javaPrimitiveType!!,
+                "int" to Int::class.javaPrimitiveType!!,
+                "long" to Long::class.javaPrimitiveType!!,
+                "float" to Float::class.javaPrimitiveType!!,
+                "double" to Double::class.javaPrimitiveType!!,
+            )
+
+        private fun primitiveClass(name: String): Class<*> =
+            primitiveClasses[name] ?: error("Not a primitive: $name")
+    }
+
+    fun emit(): VarHandleAccessorGenerator {
+        builder.signature(
+            forClass()
+                .addInterface(
+                    parameterizedType(
+                        classType(PropertyAccessor::class.java),
+                        classType(propertyType),
+                    )
+                )
+        )
+
+        // Declare handle field(s) on the class
+        val handleDesc: FieldDescriptor
+        var setterHandleDesc: FieldDescriptor? = null
+
+        if (isFieldBased) {
+            handleDesc =
+                creator
+                    .getFieldCreator("varHandle", VarHandle::class.java)
+                    .also { it.setModifiers(Modifier.PRIVATE or Modifier.FINAL) }
+                    .fieldDescriptor
+        } else {
+            handleDesc =
+                creator
+                    .getFieldCreator("getterHandle", MethodHandle::class.java)
+                    .also { it.setModifiers(Modifier.PRIVATE or Modifier.FINAL) }
+                    .fieldDescriptor
+            if (hasSetter) {
+                setterHandleDesc =
+                    creator
+                        .getFieldCreator("setterHandle", MethodHandle::class.java)
+                        .also { it.setModifiers(Modifier.PRIVATE or Modifier.FINAL) }
+                        .fieldDescriptor
+            }
+        }
+
+        creator.use {
+            ctor(handleDesc, setterHandleDesc)
+            get(handleDesc)
+            set(handleDesc, setterHandleDesc)
+        }
+
+        return this
+    }
+
+    private fun ctor(handleDesc: FieldDescriptor, setterHandleDesc: FieldDescriptor?) {
+        val constructor = creator.getConstructorCreator(*arrayOf<String>())
+        constructor.invokeSpecialMethod(ofConstructor(Object::class.java), constructor.`this`)
+
+        val tryBlock = constructor.tryBlock()
+
+        val callerLookup =
+            tryBlock.invokeStaticMethod(
+                ofMethod(MethodHandles::class.java, "lookup", Lookup::class.java)
+            )
+
+        // Load entity class via TCCL to avoid classloader mismatch: CritterClassLoader
+        // auto-registers dev.morphia.critter.* classes creating a second incompatible version.
+        val currentThread =
+            tryBlock.invokeStaticMethod(
+                ofMethod(Thread::class.java, "currentThread", Thread::class.java)
+            )
+        val tccl =
+            tryBlock.invokeVirtualMethod(
+                ofMethod(Thread::class.java, "getContextClassLoader", ClassLoader::class.java),
+                currentThread,
+            )
+        val entityClass =
+            tryBlock.invokeStaticMethod(
+                ofMethod(
+                    Class::class.java,
+                    "forName",
+                    Class::class.java,
+                    String::class.java,
+                    Boolean::class.javaPrimitiveType,
+                    ClassLoader::class.java,
+                ),
+                tryBlock.load(entity.name),
+                tryBlock.load(true),
+                tccl,
+            )
+        val privateLookup =
+            tryBlock.invokeStaticMethod(
+                ofMethod(
+                    MethodHandles::class.java,
+                    "privateLookupIn",
+                    Lookup::class.java,
+                    Class::class.java,
+                    Lookup::class.java,
+                ),
+                entityClass,
+                callerLookup,
+            )
+
+        if (isFieldBased) {
+            val fieldTypeClass = tryBlock.loadClass(propertyType)
+            val handle =
+                tryBlock.invokeVirtualMethod(
+                    ofMethod(
+                        Lookup::class.java,
+                        "findVarHandle",
+                        VarHandle::class.java,
+                        Class::class.java,
+                        String::class.java,
+                        Class::class.java,
+                    ),
+                    privateLookup,
+                    entityClass,
+                    tryBlock.load(propertyName),
+                    fieldTypeClass,
+                )
+            tryBlock.writeInstanceField(handleDesc, tryBlock.`this`, handle)
+        } else {
+            // Getter MethodHandle
+            val returnTypeClass = tryBlock.loadClass(propertyType)
+            val getterMethodType =
+                tryBlock.invokeStaticMethod(
+                    ofMethod(
+                        MethodType::class.java,
+                        "methodType",
+                        MethodType::class.java,
+                        Class::class.java,
+                    ),
+                    returnTypeClass,
+                )
+            val getterHandle =
+                tryBlock.invokeVirtualMethod(
+                    ofMethod(
+                        Lookup::class.java,
+                        "findVirtual",
+                        MethodHandle::class.java,
+                        Class::class.java,
+                        String::class.java,
+                        MethodType::class.java,
+                    ),
+                    privateLookup,
+                    entityClass,
+                    tryBlock.load(getterName!!),
+                    getterMethodType,
+                )
+            tryBlock.writeInstanceField(handleDesc, tryBlock.`this`, getterHandle)
+
+            // Setter MethodHandle (if applicable)
+            if (setterHandleDesc != null) {
+                val voidClass = tryBlock.loadClass(Void.TYPE)
+                val paramTypeClass = tryBlock.loadClass(propertyType)
+                val setterMethodType =
+                    tryBlock.invokeStaticMethod(
+                        ofMethod(
+                            MethodType::class.java,
+                            "methodType",
+                            MethodType::class.java,
+                            Class::class.java,
+                            Class::class.java,
+                        ),
+                        voidClass,
+                        paramTypeClass,
+                    )
+                val setterHandle =
+                    tryBlock.invokeVirtualMethod(
+                        ofMethod(
+                            Lookup::class.java,
+                            "findVirtual",
+                            MethodHandle::class.java,
+                            Class::class.java,
+                            String::class.java,
+                            MethodType::class.java,
+                        ),
+                        privateLookup,
+                        entityClass,
+                        tryBlock.load(setterName!!),
+                        setterMethodType,
+                    )
+                tryBlock.writeInstanceField(setterHandleDesc, tryBlock.`this`, setterHandle)
+            }
+        }
+
+        val catchBlock = tryBlock.addCatch(ReflectiveOperationException::class.java)
+        val ex = catchBlock.getCaughtException()
+        val wrapped =
+            catchBlock.newInstance(
+                ofConstructor(RuntimeException::class.java, Throwable::class.java),
+                ex,
+            )
+        catchBlock.throwException(wrapped)
+
+        constructor.returnVoid()
+        constructor.close()
+    }
+
+    private fun get(handleDesc: FieldDescriptor) {
+        val method =
+            creator.getMethodCreator(
+                ofMethod(generatedType, "get", Object::class.java.name, Object::class.java.name)
+            )
+        method.signature =
+            forMethod()
+                .addTypeParameter(typeVariable("S"))
+                .setReturnType(classType(propertyType))
+                .addParameterType(typeVariable("S"))
+                .build()
+        method.setParameterNames(arrayOf("model"))
+
+        // Do NOT checkCast to entity type — VarHandle/MethodHandle performs its own type check
+        // and casting would cause classloader mismatch (CritterClassLoader vs app classloader).
+        val model = method.getMethodParam(0)
+        val handleRef = method.readInstanceField(handleDesc, method.`this`)
+
+        val result =
+            if (isFieldBased) {
+                method.invokeVirtualMethod(
+                    ofMethod(
+                        VarHandle::class.java,
+                        "get",
+                        Object::class.java.name,
+                        Object::class.java.name,
+                    ),
+                    handleRef,
+                    model,
+                )
+            } else {
+                method.invokeVirtualMethod(
+                    ofMethod(
+                        MethodHandle::class.java,
+                        "invoke",
+                        Object::class.java.name,
+                        Object::class.java.name,
+                    ),
+                    handleRef,
+                    model,
+                )
+            }
+
+        val boxed = if (isPrimitive) method.smartCast(result, wrapperType) else result
+        method.returnValue(boxed)
+    }
+
+    private fun set(handleDesc: FieldDescriptor, setterHandleDesc: FieldDescriptor?) {
+        val method =
+            creator.getMethodCreator(
+                ofMethod(
+                    generatedType,
+                    "set",
+                    "void",
+                    Object::class.java.name,
+                    Object::class.java.name,
+                )
+            )
+        method.signature =
+            forMethod()
+                .addTypeParameter(typeVariable("S"))
+                .setReturnType(voidType())
+                .addParameterType(typeVariable("S"))
+                .addParameterType(classType(propertyType))
+                .build()
+        method.setParameterNames(arrayOf("model", "value"))
+
+        if (!isFieldBased && setterHandleDesc == null) {
+            // Read-only property — no setter
+            method.throwException(
+                UnsupportedOperationException::class.java,
+                "Property '$propertyName' is read-only",
+            )
+            return
+        }
+
+        // Do NOT checkCast to entity type — same classloader mismatch concern as in get().
+        val castModel = method.getMethodParam(0)
+        val castValue =
+            if (isPrimitive) {
+                val boxed = method.checkCast(method.getMethodParam(1), wrapperType)
+                method.smartCast(boxed, propertyType)
+            } else {
+                method.checkCast(method.getMethodParam(1), propertyType)
+            }
+
+        val handleRef =
+            if (isFieldBased) method.readInstanceField(handleDesc, method.`this`)
+            else method.readInstanceField(setterHandleDesc!!, method.`this`)
+
+        if (isFieldBased) {
+            method.invokeVirtualMethod(
+                ofMethod(
+                    VarHandle::class.java,
+                    "set",
+                    "void",
+                    Object::class.java.name,
+                    Object::class.java.name,
+                ),
+                handleRef,
+                castModel,
+                castValue,
+            )
+        } else {
+            method.invokeVirtualMethod(
+                ofMethod(
+                    MethodHandle::class.java,
+                    "invoke",
+                    "void",
+                    Object::class.java.name,
+                    Object::class.java.name,
+                ),
+                handleRef,
+                castModel,
+                castValue,
+            )
+        }
+
+        method.returnValue(null)
+    }
+}

--- a/critter/core/src/test/kotlin/dev/morphia/critter/parser/TestVarHandleAccessor.kt
+++ b/critter/core/src/test/kotlin/dev/morphia/critter/parser/TestVarHandleAccessor.kt
@@ -1,0 +1,89 @@
+package dev.morphia.critter.parser
+
+import dev.morphia.critter.Critter.Companion.critterPackage
+import dev.morphia.critter.CritterClassLoader
+import dev.morphia.critter.parser.gizmo.CritterGizmoGenerator
+import dev.morphia.critter.sources.Example
+import dev.morphia.critter.titleCase
+import org.bson.codecs.pojo.PropertyAccessor
+import org.testng.Assert.assertEquals
+import org.testng.Assert.assertNull
+import org.testng.annotations.BeforeClass
+import org.testng.annotations.Test
+
+class TestVarHandleAccessor {
+    private lateinit var classLoader: CritterClassLoader
+
+    @BeforeClass
+    fun setup() {
+        classLoader = CritterClassLoader()
+        CritterGizmoGenerator.generate(Example::class.java, classLoader, runtimeMode = true)
+    }
+
+    @Test
+    fun testEntityNotModified() {
+        // In runtime mode the entity class must NOT have synthetic __readXxx/__writeXxx methods
+        // (as opposed to the __readXxxTemplate methods that exist in the source)
+        val methods = Example::class.java.declaredMethods.map { it.name }
+        val syntheticRead = methods.filter { it.startsWith("__read") && !it.endsWith("Template") }
+        val syntheticWrite = methods.filter { it.startsWith("__write") && !it.endsWith("Template") }
+        assert(syntheticRead.isEmpty()) {
+            "Entity class should not have synthetic __read methods but found: $syntheticRead"
+        }
+        assert(syntheticWrite.isEmpty()) {
+            "Entity class should not have synthetic __write methods but found: $syntheticWrite"
+        }
+    }
+
+    @Test
+    fun testStringField() {
+        val entity = Example()
+        val accessor = loadAccessor<String>(Example::class.java, "name")
+
+        assertNull(accessor.get(entity))
+        accessor.set(entity, "hello")
+        assertEquals(accessor.get(entity), "hello")
+    }
+
+    @Test
+    fun testIntPrimitiveField() {
+        val entity = Example()
+        val accessor = loadAccessor<Any>(Example::class.java, "age")
+
+        // Default value is 21 (set in field initializer)
+        assertEquals(accessor.get(entity), 21)
+        accessor.set(entity, 42)
+        assertEquals(accessor.get(entity), 42)
+    }
+
+    @Test
+    fun testLongBoxedField() {
+        val entity = Example()
+        val accessor = loadAccessor<Any>(Example::class.java, "salary")
+
+        // Default value is 2L (set in field initializer)
+        assertEquals(accessor.get(entity), 2L)
+        accessor.set(entity, 100_000L)
+        assertEquals(accessor.get(entity), 100_000L)
+    }
+
+    @Test
+    fun testAccessorsInstantiatable() {
+        // All three generated accessor classes must be loadable with no-arg constructor
+        listOf("name", "age", "salary").forEach { field ->
+            val cls =
+                classLoader.loadClass(
+                    "${critterPackage(Example::class.java)}.${field.titleCase()}Accessor"
+                )
+            cls.getConstructor().newInstance()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> loadAccessor(entityType: Class<*>, fieldName: String): PropertyAccessor<T> {
+        val accessorClass =
+            classLoader.loadClass("${critterPackage(entityType)}.${fieldName.titleCase()}Accessor")
+                as Class<PropertyAccessor<T>>
+        return accessorClass.getConstructor().newInstance()
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `VarHandleAccessorGenerator` — a Gizmo-based generator that produces `PropertyAccessor<T>` implementations using `VarHandle` (field-based) and `MethodHandle` (method-based properties) instead of delegating to `__readXxx`/`__writeXxx` synthetic methods injected into entity bytecode
- Adds `runtimeMode` flag to `PropertyFinder` and `CritterGizmoGenerator`: when `true`, entity bytecode is not modified and VarHandle accessors are generated instead
- This is the accessor generation path that `CritterMapper` (Phase 4) will use at runtime

Closes tasks in #4185.

## Key design notes

- Entity class loaded via `Thread.currentThread().contextClassLoader` in the generated constructor to avoid classloader mismatch with `CritterClassLoader` (which auto-registers `dev.morphia.critter.*` classes)
- No `checkCast` to entity type in `get()`/`set()` — `VarHandle`/`MethodHandle` performs its own type verification
- Method-based read-only properties (no setter) throw `UnsupportedOperationException` from `set()`, matching compile-time behavior

## Test plan

- [x] `TestVarHandleAccessor` — 5 tests: String field, int primitive, Long boxed, entity not modified, all accessors instantiatable
- [x] Full `critter-core` suite (57 tests) passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)