### PR TITLE
Add MongoDriverInformation to identify Morphia client connections

### DIFF
--- a/core/src/main/java/dev/morphia/MorphiaDatastore.java
+++ b/core/src/main/java/dev/morphia/MorphiaDatastore.java
@@ -1,6 +1,7 @@
 package dev.morphia;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -12,6 +13,7 @@ import java.util.stream.Collectors;
 
 import com.mongodb.ClientSessionOptions;
 import com.mongodb.MongoCommandException;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.MongoException;
 import com.mongodb.MongoWriteException;
 import com.mongodb.WriteConcern;
@@ -104,6 +106,26 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 public class MorphiaDatastore implements Datastore {
     private static final Logger LOG = LoggerFactory.getLogger(Datastore.class);
 
+    private static final MongoDriverInformation DRIVER_INFO = buildDriverInfo();
+
+    private static MongoDriverInformation buildDriverInfo() {
+        MongoDriverInformation.Builder builder = MongoDriverInformation.builder().driverName("Morphia");
+        String version = MorphiaDatastore.class.getPackage().getImplementationVersion();
+        if (version != null) {
+            builder.driverVersion(version);
+        }
+        return builder.build();
+    }
+
+    private static void appendMongoClientMetadata(MongoClient mongoClient) {
+        try {
+            Method method = mongoClient.getClass().getMethod("appendMetadata", MongoDriverInformation.class);
+            method.invoke(mongoClient, DRIVER_INFO);
+        } catch (Exception e) {
+            // appendMetadata not available in this driver version — skip silently
+        }
+    }
+
     private final CodecRegistry codecRegistry;
 
     private final Mapper mapper;
@@ -139,6 +161,7 @@ public class MorphiaDatastore implements Datastore {
     public MorphiaDatastore(MongoClient client, MorphiaConfig config, ClassLoader classLoader) {
         this.classLoader = classLoader;
         this.mongoClient = client;
+        appendMongoClientMetadata(client);
         this.mapper = createMapper(config, classLoader);
         this.queryFactory = mapper.getConfig().queryFactory();
         importModels();


### PR DESCRIPTION
The PR incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md#supporting-wrapping-libraries) specification for the connection handshake to allow library details to be included in the metadata written to `mongos` or `mongod` logs.

For example, this change would allow server-side logs such as the following:

> {"t":{"$date":"2025-07-26T11:33:05.688+00:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn70990","msg":"client metadata","attr":{"remote":"192.168.0.1:34567","client":"conn70990","negotiatedCompressors":["zstd"],"doc":{"application":{"name":"morphia-test"},`"driver":{"name":"mongo-java-driver|reactive-streams|Morphia"`,"version":"5.0.0"},"os":{"type":"Linux","name":"Linux","architecture":"amd64","version":"6.1.119-129.201.amzn2023.x86_64"},"platform":"Java/Amazon.com Inc./21.0.8+9-LTS"}}}

For anyone hosting clusters with connections coming from different applications this can help differentiate connections and facilitate log analysis.

This is effectively the same approach taken by Spring Data MongoDB (see [SpringDataMongoDB.java](https://github.com/spring-projects/spring-data-mongodb/blob/main/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/SpringDataMongoDB.java#L37-L47), [AbstractMongoClientConfiguration.java](https://github.com/spring-projects/spring-data-mongodb/blob/024d49d4df7cba4eb970cbbd651416742fe1bebf/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractMongoClientConfiguration.java#L107-L109))