### PR TITLE
Configure revapi to run as part of the audits job

### DIFF
--- a/config/revapi.json
+++ b/config/revapi.json
@@ -22,7 +22,7 @@
           },
           {
             "matcher": "java-package",
-            "match": "/.*\\.codec(\\..*)?/"
+            "match": "/.*codec.*/"
           }
         ]
       }

--- a/config/revapi.json
+++ b/config/revapi.json
@@ -1,24 +1,5 @@
 [
   {
-    "extension": "revapi.versions",
-    "configuration": {
-      "enabled": true,
-      "semantic0": true,
-      "strictSemver": true,
-      "versionIncreaseAllows": {
-        "major": {
-          "severity": "BREAKING"
-        },
-        "minor": {
-          "severity": "NON_BREAKING"
-        },
-        "patch": {
-          "severity": "EQUIVALENT"
-        }
-      }
-    }
-  },
-  {
     "extension": "revapi.filter",
     "configuration": {
       "elements": {
@@ -32,46 +13,19 @@
             "match": "@dev.morphia.annotations.internal.MorphiaExperimental ^*;"
           },
           {
-            "matcher": "java",
-            "match": "class dev.morphia.sofia.Sofia {}"
-          },
-          {
-            "matcher": "java",
-            "match": "type ^* implements com.mongodb.session.ClientSession {}"
+            "matcher": "java-package",
+            "match": "/.*\\.internal(\\..*)?/"
           },
           {
             "matcher": "java-package",
-            "match": "/.*codec.*/"
+            "match": "/.*\\.experimental(\\..*)?/"
           },
           {
             "matcher": "java-package",
-            "match": "/com.mongodb.*/"
-          },
-          {
-            "matcher": "java-package",
-            "match": "/org.bson.*/"
-          },
-          {
-            "matcher": "java-package",
-            "match": "/.*internal.*/"
-          },
-          {
-            "matcher": "java-package",
-            "match": "/.*experimental.*/"
-          },
-          {
-            "matcher": "java-package",
-            "match": "dev.morphia.annotations.internal"
+            "match": "/.*\\.codec(\\..*)?/"
           }
         ]
       }
-    }
-  },
-  {
-    "extension": "revapi.differences",
-    "configuration": {
-      "ignore": true,
-      "differences": []
     }
   }
 ]

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -249,9 +249,29 @@
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>audits</id>
+            <activation>
+                <property>
+                    <name>audits</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
                     <plugin>
                         <groupId>org.revapi</groupId>
                         <artifactId>revapi-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>api-check</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -109,19 +109,9 @@
                             <version>${revapi.java.version}</version>
                         </dependency>
                     </dependencies>
-                    <executions>
-                        <execution>
-                            <id>revapi</id>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                            <phase>none</phase>
-                        </execution>
-                    </executions>
                     <configuration>
-                        <failBuildOnProblemsFound>true</failBuildOnProblemsFound>
                         <analysisConfigurationFiles>
-                            <analysisConfigurationFile>${maven.multiModuleProjectDirectory}/config/revapi.json</analysisConfigurationFile>
+                            <file>${maven.multiModuleProjectDirectory}/config/revapi.json</file>
                         </analysisConfigurationFiles>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
## Summary

- Move `revapi:check` out of the `code-audits` profile and into a new `audits` profile in `core/pom.xml`, activated by `-Daudits` — the flag passed by `audits.yml`
- Remove the `<phase>none</phase>` lifecycle-suppression trick from root `pluginManagement`; the profile-scoped execution now controls when the check runs
- Fix the config file element name from `<analysisConfigurationFile>` to `<file>` per the [revapi-maven-plugin docs](https://revapi.org/revapi-maven-plugin/0.15.1/configuring-revapi.html)
- Rewrite `config/revapi.json` from scratch in the modern array format, retaining only `revapi.filter` with package-level exclusions for internal, experimental, and codec packages

## What changed and why

**Before:** RevAPI was wired into the `code-audits` profile (triggered by `-Dcode-audits`), with a `<phase>none</phase>` hack in root `pluginManagement` to suppress it everywhere else. The `audits.yml` workflow passes `-Daudits`, so revapi never actually ran there.

**After:** RevAPI has a clean, self-contained execution inside an `audits` profile in `core/pom.xml`. Running `./mvnw -Daudits` (or `./mvnw install -Daudits`) now binds `revapi:check` to the `verify` phase for the core module and fails the build on any API incompatibility.

## Test plan

- [ ] Run `./mvnw install -pl :morphia-core -Daudits -DskipTests -Ddeploy.skip=true` and confirm `revapi:check` executes
- [ ] Confirm `./mvnw install -pl :morphia-core -DskipTests -Ddeploy.skip=true` (no flag) does **not** run revapi
- [ ] Confirm `./mvnw install -pl :morphia-core -Dcode-audits -DskipTests -Ddeploy.skip=true` still runs spotbugs (revapi should not run)

https://claude.ai/code/session_01GkmqCe8N2JvJB7tqCD3w3q

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkmqCe8N2JvJB7tqCD3w3q)_