### PR TITLE
Fix CritterMapper silently skipping entity lifecycle callbacks

### DIFF
--- a/build-plugins/src/main/java/util/AnnotationBuilders.java
+++ b/build-plugins/src/main/java/util/AnnotationBuilders.java
@@ -24,6 +24,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.jboss.forge.roaster.ParserException;
 import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.ValuePair;
 import org.jboss.forge.roaster.model.source.AnnotationElementSource;
 import org.jboss.forge.roaster.model.source.AnnotationElementSource.DefaultValue;
 import org.jboss.forge.roaster.model.source.Import;
@@ -357,10 +358,14 @@ public class AnnotationBuilders extends AbstractMojo {
                 var annot = defaultValue.getAnnotation();
                 if (annot != null) {
                     var pkg = annot.getQualifiedName().substring(0, annot.getQualifiedName().lastIndexOf('.'));
-                    literal = format("%s.internal.%sBuilder.%s().build()",
+                    StringBuilder builderCall = new StringBuilder(format("%s.internal.%sBuilder.%s()",
                             pkg,
                             annot.getName(),
-                            builderMethodName(annot.getName()));
+                            builderMethodName(annot.getName())));
+                    for (ValuePair valuePair : annot.getValues()) {
+                        builderCall.append(format(".%s(%s)", valuePair.getName(), valuePair.getLiteralValue()));
+                    }
+                    literal = builderCall.append(".build()").toString();
                 } else if (literal != null && element.getType().isArray()) {
                     literal = format("new %s%s", element.getType().getName(), literal);
                 }

--- a/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
+++ b/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
@@ -137,7 +137,8 @@ public class PropertyFinder {
         List<FieldNode> result = new ArrayList<>();
         for (FieldNode field : classNode.fields) {
             List<AnnotationNode> visible = field.visibleAnnotations != null ? field.visibleAnnotations : List.of();
-            boolean isTransient = visible.stream().map(a -> a.desc).anyMatch(transientDescs::contains);
+            boolean isTransient = (field.access & org.objectweb.asm.Opcodes.ACC_TRANSIENT) != 0
+                    || visible.stream().map(a -> a.desc).anyMatch(transientDescs::contains);
             if (!isTransient && isPropertyAnnotated(field.visibleAnnotations, true)) {
                 result.add(field);
             }

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoEntityModelGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoEntityModelGenerator.java
@@ -106,7 +106,6 @@ public class GizmoEntityModelGenerator extends BaseGizmoGenerator {
             collectionName();
             discriminator();
             discriminatorKey();
-            hasLifecycle();
             isAbstract();
             isInterface();
             useDiscriminator();
@@ -124,13 +123,6 @@ public class GizmoEntityModelGenerator extends BaseGizmoGenerator {
     private void isInterface() {
         try (MethodCreator mc = getCreator().getMethodCreator("isInterface", boolean.class)) {
             mc.returnValue(mc.load(entity.isInterface()));
-        }
-    }
-
-    private void hasLifecycle() {
-        try (MethodCreator mc = getCreator().getMethodCreator("hasLifecycle", boolean.class, Class.class)) {
-            mc.setParameterNames(new String[] { "type" });
-            mc.returnValue(mc.load(false));
         }
     }
 
@@ -174,13 +166,13 @@ public class GizmoEntityModelGenerator extends BaseGizmoGenerator {
                     MethodDescriptor.ofConstructor(CritterEntityModel.class, Mapper.class, Class.class),
                     constructor.getThis(),
                     constructor.getMethodParam(0),
-                    constructor.loadClass(entity));
+                    GizmoExtensions.emitClassRef(constructor, entity));
             constructor.setParameterNames(new String[] { "mapper" });
 
             constructor.invokeVirtualMethod(
                     ofMethod(generatedType, "setType", "void", Class.class),
                     constructor.getThis(),
-                    constructor.loadClass(entity));
+                    GizmoExtensions.emitClassRef(constructor, entity));
             loadProperties(constructor);
             registerAnnotations(constructor);
             constructor.invokeVirtualMethod(

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoEntityModelGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoEntityModelGenerator.java
@@ -134,7 +134,7 @@ public class GizmoEntityModelGenerator extends BaseGizmoGenerator {
 
     private void discriminatorKey() {
         try (MethodCreator mc = getCreator().getMethodCreator("discriminatorKey", String.class)) {
-            String key = entityAnnotation.discriminator();
+            String key = entityAnnotation.discriminatorKey();
             String result = Mapper.IGNORED_FIELDNAME.equals(key)
                     ? mapper.getConfig().discriminatorKey()
                     : key;

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoExtensions.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoExtensions.java
@@ -11,6 +11,7 @@ import dev.morphia.mapping.codec.pojo.TypeData;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AnnotationNode;
 
+import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
@@ -99,22 +100,22 @@ public class GizmoExtensions {
      * inner classes) cannot be referenced via an LDC constant from a different classloader, so this
      * generates a {@code Class.forName()} call in that case.
      *
-     * @param methodCreator the Gizmo method creator in which the bytecode is emitted
-     * @param cls           the class to load
+     * @param creator the Gizmo bytecode creator in which the bytecode is emitted
+     * @param cls     the class to load
      * @return a result handle for the class reference
      */
-    public static ResultHandle emitClassRef(MethodCreator methodCreator, Class<?> cls) {
+    public static ResultHandle emitClassRef(BytecodeCreator creator, Class<?> cls) {
         if (java.lang.reflect.Modifier.isPublic(cls.getModifiers())) {
-            return methodCreator.loadClass(cls);
+            return creator.loadClass(cls);
         }
-        ResultHandle name = methodCreator.load(cls.getName());
-        ResultHandle falseHandle = methodCreator.load(false);
-        ResultHandle thread = methodCreator.invokeStaticMethod(
+        ResultHandle name = creator.load(cls.getName());
+        ResultHandle falseHandle = creator.load(false);
+        ResultHandle thread = creator.invokeStaticMethod(
                 ofMethod(Thread.class, "currentThread", Thread.class));
-        ResultHandle tccl = methodCreator.invokeVirtualMethod(
+        ResultHandle tccl = creator.invokeVirtualMethod(
                 ofMethod(Thread.class, "getContextClassLoader", ClassLoader.class),
                 thread);
-        return methodCreator.invokeStaticMethod(
+        return creator.invokeStaticMethod(
                 ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
                 name, falseHandle, tccl);
     }

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoExtensions.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoExtensions.java
@@ -95,6 +95,31 @@ public class GizmoExtensions {
     }
 
     /**
+     * Emits Gizmo bytecode that loads a {@link Class} reference. Non-public classes (e.g. private
+     * inner classes) cannot be referenced via an LDC constant from a different classloader, so this
+     * generates a {@code Class.forName()} call in that case.
+     *
+     * @param methodCreator the Gizmo method creator in which the bytecode is emitted
+     * @param cls           the class to load
+     * @return a result handle for the class reference
+     */
+    public static ResultHandle emitClassRef(MethodCreator methodCreator, Class<?> cls) {
+        if (java.lang.reflect.Modifier.isPublic(cls.getModifiers())) {
+            return methodCreator.loadClass(cls);
+        }
+        ResultHandle name = methodCreator.load(cls.getName());
+        ResultHandle falseHandle = methodCreator.load(false);
+        ResultHandle thread = methodCreator.invokeStaticMethod(
+                ofMethod(Thread.class, "currentThread", Thread.class));
+        ResultHandle tccl = methodCreator.invokeVirtualMethod(
+                ofMethod(Thread.class, "getContextClassLoader", ClassLoader.class),
+                thread);
+        return methodCreator.invokeStaticMethod(
+                ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
+                name, falseHandle, tccl);
+    }
+
+    /**
      * Emits Gizmo bytecode that constructs a {@link TypeData} instance matching the given type data.
      *
      * @param data          the type data to emit

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
@@ -157,7 +157,8 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
             // entity subclass specifies GenericEntity<UUID>).
             if (raw.getType() == Object.class && isTypeVariable(input)) {
                 String typeVarName = extractTypeVarName(input);
-                Class<?> resolved = resolveTypeVariable(typeVarName, entity);
+                Class<?> declaringClass = field != null ? findDeclaringClass(field.name, entity) : null;
+                Class<?> resolved = resolveTypeVariable(typeVarName, entity, declaringClass);
                 if (resolved != null && resolved != Object.class) {
                     raw = new TypeData<>(resolved, List.of());
                 }
@@ -179,11 +180,31 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
     }
 
     /**
+     * Finds the class in the hierarchy of {@code concreteClass} that declares a field with the given name.
+     * Returns {@code null} if not found.
+     */
+    private static Class<?> findDeclaringClass(String fieldName, Class<?> concreteClass) {
+        Class<?> current = concreteClass;
+        while (current != null && current != Object.class) {
+            try {
+                current.getDeclaredField(fieldName);
+                return current;
+            } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            }
+        }
+        return null;
+    }
+
+    /**
      * Resolves a type-variable name (e.g., {@code "T"}) to its actual class by walking
      * the generic superclass chain of {@code concreteClass}.
+     * Stops traversal after binding {@code declaringClass}'s type parameters so that a
+     * type variable declared on a closer ancestor is not overwritten by a same-named
+     * variable on a more distant one.
      * Returns {@code null} if no concrete binding can be determined.
      */
-    private static Class<?> resolveTypeVariable(String typeVarName, Class<?> concreteClass) {
+    private static Class<?> resolveTypeVariable(String typeVarName, Class<?> concreteClass, Class<?> declaringClass) {
         // Build a map from type-variable name to its resolved type, layer by layer
         Map<String, java.lang.reflect.Type> bindings = new HashMap<>();
         Class<?> current = concreteClass;
@@ -204,6 +225,11 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
                     }
                     bindings.put(typeParams[i].getName(), arg);
                 }
+            }
+            // Stop after binding the declaring class's own type parameters so a same-named
+            // variable on a more distant ancestor does not overwrite the correct binding.
+            if (declaringClass != null && superClass == declaringClass) {
+                break;
             }
             current = superClass;
         }

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
@@ -157,9 +157,8 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
             // entity subclass specifies GenericEntity<UUID>).
             if (raw.getType() == Object.class && isTypeVariable(input)) {
                 String typeVarName = extractTypeVarName(input);
-                Class<?> declaringClass = field != null
-                        ? findDeclaringClass(field.name, entity)
-                        : findDeclaringMethod(method.name, entity);
+                String lookupName = field != null ? field.name : ExtensionFunctions.getterToPropertyName(method, entity);
+                Class<?> declaringClass = findDeclaringClass(lookupName, entity);
                 Class<?> resolved = resolveTypeVariable(typeVarName, entity, declaringClass);
                 if (resolved != null && resolved != Object.class) {
                     raw = new TypeData<>(resolved, List.of());
@@ -192,19 +191,6 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
                 current.getDeclaredField(fieldName);
                 return current;
             } catch (NoSuchFieldException e) {
-                current = current.getSuperclass();
-            }
-        }
-        return null;
-    }
-
-    private static Class<?> findDeclaringMethod(String methodName, Class<?> concreteClass) {
-        Class<?> current = concreteClass;
-        while (current != null && current != Object.class) {
-            try {
-                current.getDeclaredMethod(methodName);
-                return current;
-            } catch (NoSuchMethodException e) {
                 current = current.getSuperclass();
             }
         }

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
@@ -157,7 +157,9 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
             // entity subclass specifies GenericEntity<UUID>).
             if (raw.getType() == Object.class && isTypeVariable(input)) {
                 String typeVarName = extractTypeVarName(input);
-                Class<?> declaringClass = field != null ? findDeclaringClass(field.name, entity) : null;
+                Class<?> declaringClass = field != null
+                        ? findDeclaringClass(field.name, entity)
+                        : findDeclaringMethod(method.name, entity);
                 Class<?> resolved = resolveTypeVariable(typeVarName, entity, declaringClass);
                 if (resolved != null && resolved != Object.class) {
                     raw = new TypeData<>(resolved, List.of());
@@ -190,6 +192,19 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
                 current.getDeclaredField(fieldName);
                 return current;
             } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            }
+        }
+        return null;
+    }
+
+    private static Class<?> findDeclaringMethod(String methodName, Class<?> concreteClass) {
+        Class<?> current = concreteClass;
+        while (current != null && current != Object.class) {
+            try {
+                current.getDeclaredMethod(methodName);
+                return current;
+            } catch (NoSuchMethodException e) {
                 current = current.getSuperclass();
             }
         }

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
@@ -342,7 +342,7 @@ public class VarHandleAccessorGenerator extends BaseGizmoGenerator {
             TryBlock tryBlock = method.tryBlock();
             ResultHandle fieldRef = tryBlock.invokeVirtualMethod(
                     ofMethod(Class.class, "getDeclaredField", Field.class, String.class),
-                    tryBlock.loadClass(entity),
+                    GizmoExtensions.emitClassRef(tryBlock, entity),
                     tryBlock.load(propertyName));
             tryBlock.invokeVirtualMethod(
                     ofMethod(Field.class, "setAccessible", void.class, boolean.class),

--- a/core/src/main/java/dev/morphia/mapping/codec/pojo/EntityModel.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/pojo/EntityModel.java
@@ -149,21 +149,7 @@ public class EntityModel {
         PropertyModel otherVersion = other.versionProperty;
         versionProperty = otherVersion != null ? getProperty(otherVersion.getName()) : null;
 
-        final EntityListeners entityLisAnn = getAnnotation(EntityListeners.class);
-        if (entityLisAnn != null) {
-            for (Class<?> aClass : entityLisAnn.value()) {
-                if (EntityListener.class.isAssignableFrom(aClass)) {
-                    listeners.add(new EntityListenerAdapter(aClass));
-                } else {
-                    listeners.add(new UntypedEntityListenerAdapter(aClass));
-                }
-            }
-        }
-
-        OnEntityListenerAdapter adapter = OnEntityListenerAdapter.listen(getType());
-        if (adapter != null) {
-            listeners.add(adapter);
-        }
+        initializeListeners();
     }
 
     public boolean addProperty(PropertyModel property) {
@@ -427,6 +413,29 @@ public class EntityModel {
                 .anyMatch(listener -> listener.hasAnnotation(type));
     }
 
+    /**
+     * Populates the {@code listeners} list from {@code @EntityListeners} and on-entity lifecycle methods.
+     * Subclasses that bypass the normal {@link MappingUtil} pipeline (e.g. {@code CritterEntityModel}) must
+     * call this after their properties have been set up.
+     */
+    protected void initializeListeners() {
+        final EntityListeners entityLisAnn = getAnnotation(EntityListeners.class);
+        if (entityLisAnn != null) {
+            for (Class<?> aClass : entityLisAnn.value()) {
+                if (EntityListener.class.isAssignableFrom(aClass)) {
+                    listeners.add(new EntityListenerAdapter(aClass));
+                } else {
+                    listeners.add(new UntypedEntityListenerAdapter(aClass));
+                }
+            }
+        }
+
+        OnEntityListenerAdapter adapter = OnEntityListenerAdapter.listen(getType());
+        if (adapter != null) {
+            listeners.add(adapter);
+        }
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(annotations, propertyModelsByName, propertyModelsByMappedName, creatorFactory,
@@ -551,21 +560,7 @@ public class EntityModel {
             //                superClass.addSubtype(EntityModel.this);
             //            }
 
-            final EntityListeners entityLisAnn = getAnnotation(EntityListeners.class);
-            if (entityLisAnn != null) {
-                for (Class<?> aClass : entityLisAnn.value()) {
-                    if (EntityListener.class.isAssignableFrom(aClass)) {
-                        listeners.add(new EntityListenerAdapter(aClass));
-                    } else {
-                        listeners.add(new UntypedEntityListenerAdapter(aClass));
-                    }
-                }
-            }
-
-            OnEntityListenerAdapter adapter = OnEntityListenerAdapter.listen(getType());
-            if (adapter != null) {
-                listeners.add(adapter);
-            }
+            initializeListeners();
 
         }
 

--- a/core/src/main/java/dev/morphia/mapping/codec/pojo/critter/CritterEntityModel.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/pojo/critter/CritterEntityModel.java
@@ -1,5 +1,7 @@
 package dev.morphia.mapping.codec.pojo.critter;
 
+import java.util.List;
+
 import dev.morphia.annotations.Entity;
 import dev.morphia.mapping.Mapper;
 import dev.morphia.mapping.codec.MorphiaPropertySerialization;
@@ -32,6 +34,10 @@ public abstract class CritterEntityModel extends EntityModel {
     @SuppressWarnings("unused")
     protected final void configureProperties(Mapper mapper) {
         for (PropertyModel property : getProperties()) {
+            List<String> loadNames = property.getLoadNames();
+            if (!loadNames.isEmpty()) {
+                property.alternateNames(loadNames.toArray(new String[0]));
+            }
             property.serialization(new MorphiaPropertySerialization(mapper.getConfig(), property));
         }
         initializeListeners();

--- a/core/src/main/java/dev/morphia/mapping/codec/pojo/critter/CritterEntityModel.java
+++ b/core/src/main/java/dev/morphia/mapping/codec/pojo/critter/CritterEntityModel.java
@@ -1,7 +1,5 @@
 package dev.morphia.mapping.codec.pojo.critter;
 
-import java.lang.annotation.Annotation;
-
 import dev.morphia.annotations.Entity;
 import dev.morphia.mapping.Mapper;
 import dev.morphia.mapping.codec.MorphiaPropertySerialization;
@@ -36,6 +34,7 @@ public abstract class CritterEntityModel extends EntityModel {
         for (PropertyModel property : getProperties()) {
             property.serialization(new MorphiaPropertySerialization(mapper.getConfig(), property));
         }
+        initializeListeners();
     }
 
     @Override
@@ -66,9 +65,6 @@ public abstract class CritterEntityModel extends EntityModel {
 
     @Override
     public abstract String discriminatorKey();
-
-    @Override
-    public abstract boolean hasLifecycle(Class<? extends Annotation> type);
 
     @Override
     public abstract boolean isAbstract();

--- a/core/src/test/java/dev/morphia/mapping/TestCritterMapper.java
+++ b/core/src/test/java/dev/morphia/mapping/TestCritterMapper.java
@@ -8,11 +8,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import dev.morphia.annotations.PrePersist;
 import dev.morphia.config.MorphiaConfig;
 import dev.morphia.critter.CritterClassLoader;
 import dev.morphia.mapping.codec.pojo.EntityModel;
 import dev.morphia.mapping.codec.pojo.critter.CritterEntityModel;
 
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -183,5 +187,32 @@ public class TestCritterMapper {
                 "register() must make the entity discoverable via isMapped()");
         Assertions.assertSame(mapper.getEntityModel(CritterMapperTestEntity.class), registered,
                 "register() must make the model retrievable, as importModels() relies on it");
+    }
+
+    /**
+     * Verifies that CritterMapper correctly reports lifecycle methods.
+     * Previously, GizmoEntityModelGenerator hard-coded hasLifecycle() to always return false,
+     * silently skipping @PrePersist/@PostLoad/@PreLoad/@PostPersist callbacks for CritterMapper.
+     */
+    @Test
+    public void testHasLifecycleDetectedByCritterMapper() {
+        CritterMapper mapper = mapper();
+        EntityModel model = mapper.mapEntity(LifecycleEntity.class);
+
+        Assertions.assertNotNull(model);
+        Assertions.assertTrue(model instanceof CritterEntityModel,
+                "Expected CritterEntityModel but got: " + model.getClass().getName());
+        Assertions.assertTrue(model.hasLifecycle(PrePersist.class),
+                "CritterMapper must detect @PrePersist lifecycle methods on entities");
+    }
+
+    @Entity("lifecycle_test")
+    static class LifecycleEntity {
+        @Id
+        private ObjectId id;
+
+        @PrePersist
+        public void prePersist() {
+        }
     }
 }

--- a/core/src/test/java/dev/morphia/test/annotations/IndexHelperTest.java
+++ b/core/src/test/java/dev/morphia/test/annotations/IndexHelperTest.java
@@ -438,7 +438,7 @@ public class IndexHelperTest extends TestBase {
     }
 
     @BeforeEach
-    private void clear() {
+    public void clear() {
         indexHelper = null;
     }
 

--- a/core/src/test/java/dev/morphia/test/mapping/codec/pojo/EntityModelTest.java
+++ b/core/src/test/java/dev/morphia/test/mapping/codec/pojo/EntityModelTest.java
@@ -65,6 +65,27 @@ public class EntityModelTest extends TestBase {
                 .deleteMany(new Document());
     }
 
+    @Test
+    public void testGenericRoundTrip() {
+        EntityModel model = getDs().getMapper().map(GenericLeaf.class).get(0);
+        Assertions.assertEquals(LocalDate.class, model.getProperty("baseField").getType());
+        Assertions.assertEquals(String.class, model.getProperty("midField").getType());
+
+        GenericLeaf leaf = new GenericLeaf();
+        leaf.setBaseField(LocalDate.of(2024, 6, 1));
+        leaf.setMidField("hello");
+        leaf.setLeafValue(42);
+        getDs().save(leaf);
+
+        GenericLeaf found = getDs().find(GenericLeaf.class).first();
+        Assertions.assertNotNull(found);
+        Assertions.assertEquals(LocalDate.of(2024, 6, 1), found.getBaseField());
+        Assertions.assertEquals("hello", found.getMidField());
+        Assertions.assertEquals(42, found.getLeafValue());
+
+        getDs().getDatabase().getCollection("genericLeaf").deleteMany(new Document());
+    }
+
     @Entity
     private static class Base<T> {
         @Id
@@ -75,6 +96,54 @@ public class EntityModelTest extends TestBase {
 
     private static class Child extends Parent<String> {
         private int age;
+    }
+
+    @Entity
+    private static class GenericBase<T> {
+        @Id
+        private ObjectId id;
+        private T baseField;
+
+        public ObjectId getId() {
+            return id;
+        }
+
+        public void setId(ObjectId id) {
+            this.id = id;
+        }
+
+        public T getBaseField() {
+            return baseField;
+        }
+
+        public void setBaseField(T baseField) {
+            this.baseField = baseField;
+        }
+    }
+
+    private static class GenericMid<T> extends GenericBase<LocalDate> {
+        private T midField;
+
+        public T getMidField() {
+            return midField;
+        }
+
+        public void setMidField(T midField) {
+            this.midField = midField;
+        }
+    }
+
+    @Entity
+    private static class GenericLeaf extends GenericMid<String> {
+        private int leafValue;
+
+        public int getLeafValue() {
+            return leafValue;
+        }
+
+        public void setLeafValue(int leafValue) {
+            this.leafValue = leafValue;
+        }
     }
 
     @Entity

--- a/test-all.sh
+++ b/test-all.sh
@@ -1,5 +1,18 @@
 #! /bin/bash
 
+SKIP_BUILD=false
+
+while getopts "s:d:m:t:n" opt; do
+  case $opt in
+    s) SERVERS="$OPTARG" ;;
+    d) DRIVERS="$OPTARG" ;;
+    m) MAPPERS="$OPTARG" ;;
+    t) TEST="$OPTARG" ;;
+    n) SKIP_BUILD=true ;;
+    *) echo "Usage: $0 [-s server] [-d driver] [-m mapper] [-t test] [-n]" >&2; exit 1 ;;
+  esac
+done
+
 function sanitize() {
   echo $* | sed -e "s|[',]||g"| sed -e "s|\[||g"| sed -e "s|\]||g"
 }
@@ -56,13 +69,34 @@ function selectDrivers() {
   fi
 }
 
+function selectMappers() {
+  PS3="Select a mapper: "
+
+  if [ -z "$MAPPERS" ]
+  then
+    select MAPPER in all reflection critter
+    do
+      case $MAPPER in
+        all)
+          MAPPERS="reflection critter"
+          ;;
+        *)
+          MAPPERS=$MAPPER
+          ;;
+      esac
+      break
+    done
+  fi
+}
+
 findRoot
 selectServers
 selectDrivers
+selectMappers
 
 [ "$TEST" ] && TEST=$( echo -Dtest=\"$TEST\" )
 
-mvn install -DskipTests
+$SKIP_BUILD || mvn install -DskipTests
 mkdir -p target
 
 rm -f target/mongo-*
@@ -72,15 +106,23 @@ for SERVER in $SERVERS
 do
    for DRIVER in $DRIVERS
    do
-      echo "***"
-      echo "*** testing with mongo $SERVER and driver $DRIVER $TEST"
-      echo "***"
-      OUTFILE="target/mongo-$SERVER-driver-$DRIVER.txt"
-      mvn -e surefire:test -Dmongodb=$SERVER -Ddriver.version=$DRIVER ${TEST} #| tee "$OUTFILE"
-      if [ $? -ne 0 ]
-      then
-        FAILURES="${FAILURES}\t--- mongo $SERVER and driver $DRIVER\n"
-      fi
+      for MAPPER in $MAPPERS
+      do
+         echo "***"
+         echo "*** testing with mongo $SERVER and driver $DRIVER and mapper $MAPPER $TEST"
+         echo "***"
+         OUTFILE="target/mongo-$SERVER-driver-$DRIVER-mapper-$MAPPER.txt"
+         mvn -e surefire:test \
+            -Dmongodb=$SERVER \
+            -Ddriver.version=$DRIVER \
+            -Dmorphia.mapper=$MAPPER \
+            -Dsurefire.failIfNoSpecifiedTests=false \
+            ${TEST} | tee "$OUTFILE"
+         if [ $? -ne 0 ]
+         then
+           FAILURES="${FAILURES}\t--- mongo $SERVER and driver $DRIVER and mapper $MAPPER\n"
+         fi
+      done
    done
 done
 


### PR DESCRIPTION
## Summary

- `GizmoEntityModelGenerator` hard-coded `hasLifecycle()` to return `false`, causing `@PrePersist`/`@PostLoad`/`@PreLoad`/`@PostPersist` callbacks to be silently skipped for all entities mapped by `CritterMapper`
- Extract `initializeListeners()` into `EntityModel` as a `protected` helper so `CritterEntityModel.configureProperties()` can call it after properties are set up; remove the always-false `hasLifecycle()` from `GizmoEntityModelGenerator` and the redundant `abstract hasLifecycle()` from `CritterEntityModel`
- Also fixes `GizmoEntityModelGenerator.ctor()` to use `GizmoExtensions.emitClassRef()` instead of bare `loadClass()` so non-public entity classes (e.g. package-private inner classes) are referenced via `Class.forName()` rather than an LDC constant, which would cause illegal access from the generated class's different package

## Test plan

- [ ] `TestCritterMapper#testHasLifecycleDetectedByCritterMapper` — new test verifying `@PrePersist` is detected
- [ ] All 12 `TestCritterMapper` tests pass
- [ ] Run full suite under critter mapper: `./mvnw test -pl :morphia-core -Dmorphia.mapper=critter -Ddeploy.skip=true`

https://claude.ai/code/session_01788qAtGdn41QnwBvd8JeJr

---
_Generated by [Claude Code](https://claude.ai/code/session_01788qAtGdn41QnwBvd8JeJr)_