### PR TITLE
Fix PropertyFinder not discovering inherited getter/setter pairs in METHODS mode

### DIFF
--- a/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
+++ b/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
@@ -15,6 +15,7 @@ import dev.morphia.mapping.Mapper;
 import dev.morphia.mapping.PropertyDiscovery;
 
 import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
@@ -158,8 +159,12 @@ public class PropertyFinder {
             if (node == null)
                 break;
 
+            boolean isSuperclass = current != entityType;
             for (MethodNode method : node.methods) {
                 if (!isGetter(method))
+                    continue;
+                // Private methods in a superclass are not inherited — skip them
+                if (isSuperclass && (method.access & Opcodes.ACC_PRIVATE) != 0)
                     continue;
                 String propName = getterPropertyName(method);
                 // Subclass method takes precedence — skip if already seen
@@ -170,7 +175,7 @@ public class PropertyFinder {
                     // In METHODS mode: include all getters that have a matching setter,
                     // merging annotations from both getter and setter so that annotations
                     // placed on the setter (e.g. @Version, @Text) are visible to downstream generators.
-                    MethodNode setter = findSetter(node, propName, Type.getReturnType(method.desc));
+                    MethodNode setter = findSetterInHierarchy(node, current, propName, Type.getReturnType(method.desc));
                     if (setter != null) {
                         result.add(mergeAnnotations(method, setter));
                     }
@@ -188,7 +193,8 @@ public class PropertyFinder {
     private boolean isGetter(MethodNode method) {
         return (method.name.startsWith("get") || method.name.startsWith("is"))
                 && Type.getArgumentTypes(method.desc).length == 0
-                && !Type.getReturnType(method.desc).equals(Type.VOID_TYPE);
+                && !Type.getReturnType(method.desc).equals(Type.VOID_TYPE)
+                && (method.access & Opcodes.ACC_STATIC) == 0;
     }
 
     private String getterPropertyName(MethodNode method) {
@@ -204,6 +210,25 @@ public class PropertyFinder {
             if (method.name.equals(setterName) && method.desc.equals(setterDesc)) {
                 return method;
             }
+        }
+        return null;
+    }
+
+    private MethodNode findSetterInHierarchy(ClassNode startNode, Class<?> startClass, String propName, Type returnType) {
+        ClassNode node = startNode;
+        Class<?> current = startClass;
+        while (current != null && current != Object.class) {
+            if (node == null)
+                node = readClassNode(current);
+            if (node != null) {
+                MethodNode setter = findSetter(node, propName, returnType);
+                // Private setters in a superclass are not inherited
+                if (setter != null && (setter.access & Opcodes.ACC_PRIVATE) == 0) {
+                    return setter;
+                }
+            }
+            current = current.getSuperclass();
+            node = null;
         }
         return null;
     }

--- a/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
+++ b/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
@@ -59,7 +59,7 @@ public class PropertyFinder {
      */
     public List<PropertyModelGenerator> find(Class<?> entityType, ClassNode classNode) {
         List<PropertyModelGenerator> models = new ArrayList<>();
-        List<MethodNode> methods = discoverPropertyMethods(classNode);
+        List<MethodNode> methods = discoverPropertyMethods(entityType, classNode);
         if (methods.isEmpty()) {
             List<FieldNode> fields = discoverAllFields(entityType, classNode);
             if (!runtimeMode) {
@@ -145,24 +145,41 @@ public class PropertyFinder {
         return result;
     }
 
-    private List<MethodNode> discoverPropertyMethods(ClassNode classNode) {
+    private List<MethodNode> discoverPropertyMethods(Class<?> entityType, ClassNode classNode) {
         List<MethodNode> result = new ArrayList<>();
-        for (MethodNode method : classNode.methods) {
-            if (!isGetter(method)) {
-                continue;
-            }
-            if (propertyDiscovery == PropertyDiscovery.METHODS) {
-                // In METHODS mode: include all getters that have a matching setter,
-                // merging annotations from both getter and setter so that annotations
-                // placed on the setter (e.g. @Version, @Text) are visible to downstream generators.
+        Map<String, Boolean> seen = new LinkedHashMap<>();
+
+        Class<?> current = entityType;
+        ClassNode currentNode = classNode;
+
+        while (current != null && current != Object.class) {
+            ClassNode node = currentNode != null ? currentNode : readClassNode(current);
+            if (node == null)
+                break;
+
+            for (MethodNode method : node.methods) {
+                if (!isGetter(method))
+                    continue;
                 String propName = getterPropertyName(method);
-                MethodNode setter = findSetter(classNode, propName, Type.getReturnType(method.desc));
-                if (setter != null) {
-                    result.add(mergeAnnotations(method, setter));
+                // Subclass method takes precedence — skip if already seen
+                if (seen.putIfAbsent(propName, Boolean.TRUE) != null)
+                    continue;
+
+                if (propertyDiscovery == PropertyDiscovery.METHODS) {
+                    // In METHODS mode: include all getters that have a matching setter,
+                    // merging annotations from both getter and setter so that annotations
+                    // placed on the setter (e.g. @Version, @Text) are visible to downstream generators.
+                    MethodNode setter = findSetter(node, propName, Type.getReturnType(method.desc));
+                    if (setter != null) {
+                        result.add(mergeAnnotations(method, setter));
+                    }
+                } else if (isPropertyAnnotated(method.visibleAnnotations, false)) {
+                    result.add(method);
                 }
-            } else if (isPropertyAnnotated(method.visibleAnnotations, false)) {
-                result.add(method);
             }
+
+            current = current.getSuperclass();
+            currentNode = null;
         }
         return result;
     }

--- a/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
+++ b/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
@@ -21,12 +21,16 @@ import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.MethodNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Discovers entity properties (fields or getter methods) from a parsed ASM {@link ClassNode}
  * and produces the corresponding {@link PropertyModelGenerator} instances.
  */
 public class PropertyFinder {
+    private static final Logger LOG = LoggerFactory.getLogger(PropertyFinder.class);
+
     private final Map<Class<?>, Object> providerMap;
     private final CritterClassLoader classLoader;
     private final boolean runtimeMode;
@@ -128,6 +132,7 @@ public class PropertyFinder {
         try {
             new ClassReader(inputStream).accept(node, 0);
         } catch (IOException e) {
+            LOG.warn("Failed to read bytecode for {}: {}", type.getName(), e.getMessage());
             return null;
         }
         return node;
@@ -163,11 +168,11 @@ public class PropertyFinder {
             for (MethodNode method : node.methods) {
                 if (!isGetter(method))
                     continue;
-                // Private methods in a superclass are not inherited — skip them
+                // Private methods are not inherited and cannot be invoked from a subclass context
                 if (isSuperclass && (method.access & Opcodes.ACC_PRIVATE) != 0)
                     continue;
                 String propName = getterPropertyName(method);
-                // Skip if a qualifying getter was already found at a lower level in the hierarchy
+                // Subclass definition already registered; superclass version is shadowed
                 if (seen.containsKey(propName))
                     continue;
 

--- a/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
+++ b/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
@@ -167,8 +167,8 @@ public class PropertyFinder {
                 if (isSuperclass && (method.access & Opcodes.ACC_PRIVATE) != 0)
                     continue;
                 String propName = getterPropertyName(method);
-                // Subclass method takes precedence — skip if already seen
-                if (seen.putIfAbsent(propName, Boolean.TRUE) != null)
+                // Skip if a qualifying getter was already found at a lower level in the hierarchy
+                if (seen.containsKey(propName))
                     continue;
 
                 if (propertyDiscovery == PropertyDiscovery.METHODS) {
@@ -177,9 +177,11 @@ public class PropertyFinder {
                     // placed on the setter (e.g. @Version, @Text) are visible to downstream generators.
                     MethodNode setter = findSetterInHierarchy(node, current, propName, Type.getReturnType(method.desc));
                     if (setter != null) {
+                        seen.put(propName, Boolean.TRUE);
                         result.add(mergeAnnotations(method, setter));
                     }
                 } else if (isPropertyAnnotated(method.visibleAnnotations, false)) {
+                    seen.put(propName, Boolean.TRUE);
                     result.add(method);
                 }
             }

--- a/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
+++ b/core/src/main/java/dev/morphia/critter/parser/PropertyFinder.java
@@ -126,8 +126,10 @@ public class PropertyFinder {
     private ClassNode readClassNode(Class<?> type) {
         String resourceName = "%s.class".formatted(type.getName().replace('.', '/'));
         InputStream inputStream = type.getClassLoader().getResourceAsStream(resourceName);
-        if (inputStream == null)
+        if (inputStream == null) {
+            LOG.debug("Bytecode resource not found for {}; hierarchy traversal stops here", type.getName());
             return null;
+        }
         ClassNode node = new ClassNode();
         try {
             new ClassReader(inputStream).accept(node, 0);
@@ -229,7 +231,7 @@ public class PropertyFinder {
                 node = readClassNode(current);
             if (node != null) {
                 MethodNode setter = findSetter(node, propName, returnType);
-                // Private setters in a superclass are not inherited
+                // Private setters are inaccessible from generated accessor bytecode
                 if (setter != null && (setter.access & Opcodes.ACC_PRIVATE) == 0) {
                     return setter;
                 }

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
@@ -5,6 +5,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Map;
 
@@ -136,7 +137,7 @@ public class VarHandleAccessorGenerator extends BaseGizmoGenerator {
         Class<?> current = entity;
         while (current != null && current != Object.class) {
             try {
-                java.lang.reflect.Method m = current.getDeclaredMethod(setterName, paramClass);
+                Method m = current.getDeclaredMethod(setterName, paramClass);
                 if (!Modifier.isPrivate(m.getModifiers()) && !Modifier.isStatic(m.getModifiers())) {
                     return true;
                 }

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
@@ -141,6 +141,7 @@ public class VarHandleAccessorGenerator extends BaseGizmoGenerator {
                     return true;
                 }
             } catch (NoSuchMethodException e) {
+                // expected: this class does not declare the setter; walk up to the superclass
             }
             current = current.getSuperclass();
         }

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
@@ -141,7 +141,6 @@ public class VarHandleAccessorGenerator extends BaseGizmoGenerator {
                     return true;
                 }
             } catch (NoSuchMethodException e) {
-                // not on this level, keep walking
             }
             current = current.getSuperclass();
         }

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
@@ -136,11 +136,14 @@ public class VarHandleAccessorGenerator extends BaseGizmoGenerator {
         Class<?> current = entity;
         while (current != null && current != Object.class) {
             try {
-                current.getDeclaredMethod(setterName, paramClass);
-                return true;
+                java.lang.reflect.Method m = current.getDeclaredMethod(setterName, paramClass);
+                if (!Modifier.isPrivate(m.getModifiers()) && !Modifier.isStatic(m.getModifiers())) {
+                    return true;
+                }
             } catch (NoSuchMethodException e) {
-                current = current.getSuperclass();
+                // not on this level, keep walking
             }
+            current = current.getSuperclass();
         }
         return false;
     }

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/VarHandleAccessorGenerator.java
@@ -133,12 +133,16 @@ public class VarHandleAccessorGenerator extends BaseGizmoGenerator {
                 return false;
             }
         }
-        try {
-            entity.getDeclaredMethod(setterName, paramClass);
-            return true;
-        } catch (NoSuchMethodException e) {
-            return false;
+        Class<?> current = entity;
+        while (current != null && current != Object.class) {
+            try {
+                current.getDeclaredMethod(setterName, paramClass);
+                return true;
+            } catch (NoSuchMethodException e) {
+                current = current.getSuperclass();
+            }
         }
+        return false;
     }
 
     /**

--- a/core/src/test/java/dev/morphia/mapping/TestCritterMapper.java
+++ b/core/src/test/java/dev/morphia/mapping/TestCritterMapper.java
@@ -208,7 +208,7 @@ public class TestCritterMapper {
 
     /** Base class with a getter/setter pair that the subclass inherits. */
     public static class MethodsBase {
-        private String name;
+        private transient String name;
 
         public String getName() {
             return name;

--- a/core/src/test/java/dev/morphia/mapping/TestCritterMapper.java
+++ b/core/src/test/java/dev/morphia/mapping/TestCritterMapper.java
@@ -8,11 +8,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
 import dev.morphia.config.MorphiaConfig;
 import dev.morphia.critter.CritterClassLoader;
 import dev.morphia.mapping.codec.pojo.EntityModel;
 import dev.morphia.mapping.codec.pojo.critter.CritterEntityModel;
 
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -183,5 +186,41 @@ public class TestCritterMapper {
                 "register() must make the entity discoverable via isMapped()");
         Assertions.assertSame(mapper.getEntityModel(CritterMapperTestEntity.class), registered,
                 "register() must make the model retrievable, as importModels() relies on it");
+    }
+
+    /**
+     * Verify that inherited getter/setter pairs are discovered when METHODS mode is used.
+     * Before the fix, PropertyFinder.discoverPropertyMethods() only inspected the immediate
+     * class's methods and missed getters defined in parent classes.
+     */
+    @Test
+    public void testInheritedGetterDiscoveryInMethodsMode() {
+        CritterMapper mapper = new CritterMapper(
+                MorphiaConfig.load().mapper(MapperType.CRITTER).propertyDiscovery(PropertyDiscovery.METHODS));
+        EntityModel model = mapper.mapEntity(MethodsChild.class);
+        Assertions.assertNotNull(model, "mapEntity should return a model for MethodsChild");
+        Assertions.assertTrue(model instanceof CritterEntityModel,
+                "Expected CritterEntityModel but got: " + model.getClass().getName());
+        Assertions.assertNotNull(model.getProperty("name"),
+                "Property 'name' inherited from MethodsBase should be discovered in METHODS mode");
+    }
+
+    /** Base class with a getter/setter pair that the subclass inherits. */
+    public static class MethodsBase {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Entity("methods_child")
+    public static class MethodsChild extends MethodsBase {
+        @Id
+        ObjectId id;
     }
 }

--- a/core/src/test/java/dev/morphia/mapping/TestCritterMapper.java
+++ b/core/src/test/java/dev/morphia/mapping/TestCritterMapper.java
@@ -14,6 +14,7 @@ import dev.morphia.annotations.PrePersist;
 import dev.morphia.config.MorphiaConfig;
 import dev.morphia.critter.CritterClassLoader;
 import dev.morphia.mapping.codec.pojo.EntityModel;
+import dev.morphia.mapping.codec.pojo.PropertyModel;
 import dev.morphia.mapping.codec.pojo.critter.CritterEntityModel;
 
 import org.bson.types.ObjectId;
@@ -189,11 +190,6 @@ public class TestCritterMapper {
                 "register() must make the model retrievable, as importModels() relies on it");
     }
 
-    /**
-     * Verify that inherited getter/setter pairs are discovered when METHODS mode is used.
-     * Before the fix, PropertyFinder.discoverPropertyMethods() only inspected the immediate
-     * class's methods and missed getters defined in parent classes.
-     */
     @Test
     public void testInheritedGetterDiscoveryInMethodsMode() {
         CritterMapper mapper = new CritterMapper(
@@ -206,7 +202,38 @@ public class TestCritterMapper {
                 "Property 'name' inherited from MethodsBase should be discovered in METHODS mode");
     }
 
-    /** Base class with a getter/setter pair that the subclass inherits. */
+    @Test
+    public void testMethodBasedPropertyRoundTrip() {
+        CritterMapper mapper = new CritterMapper(
+                MorphiaConfig.load().mapper(MapperType.CRITTER).propertyDiscovery(PropertyDiscovery.METHODS));
+        EntityModel model = mapper.mapEntity(MethodsChild.class);
+        PropertyModel property = model.getProperty("name");
+        Assertions.assertNotNull(property, "Property 'name' must be discovered");
+        MethodsChild instance = new MethodsChild();
+        property.getAccessor().set(instance, "hello");
+        Assertions.assertEquals("hello", property.getAccessor().get(instance),
+                "Accessor must round-trip the value written via set()");
+    }
+
+    @Test
+    public void testPrivateSuperclassGetterExcluded() {
+        CritterMapper mapper = new CritterMapper(
+                MorphiaConfig.load().mapper(MapperType.CRITTER).propertyDiscovery(PropertyDiscovery.METHODS));
+        EntityModel model = mapper.mapEntity(PrivateGetterChild.class);
+        Assertions.assertNotNull(model);
+        Assertions.assertNull(model.getProperty("secret"),
+                "Private getter in superclass must not be exposed as a property");
+    }
+
+    @Test
+    public void testStaticGetterExcluded() {
+        CritterMapper mapper = mapper();
+        EntityModel model = mapper.mapEntity(StaticGetterEntity.class);
+        Assertions.assertNotNull(model);
+        Assertions.assertNull(model.getProperty("kind"),
+                "Static getter must not be exposed as a property");
+    }
+
     public static class MethodsBase {
         private transient String name;
 
@@ -225,7 +252,35 @@ public class TestCritterMapper {
         ObjectId id;
     }
 
-    /*
+    public static class PrivateGetterBase {
+        private transient String secret;
+
+        private String getSecret() {
+            return secret;
+        }
+
+        public void setSecret(String secret) {
+            this.secret = secret;
+        }
+    }
+
+    @Entity("private_getter_child")
+    public static class PrivateGetterChild extends PrivateGetterBase {
+        @Id
+        ObjectId id;
+    }
+
+    @Entity("static_getter_entity")
+    public static class StaticGetterEntity {
+        @Id
+        ObjectId id;
+
+        public static String getKind() {
+            return "example";
+        }
+    }
+
+    /**
      * Verifies that CritterMapper correctly reports lifecycle methods.
      * Previously, GizmoEntityModelGenerator hard-coded hasLifecycle() to always return false,
      * silently skipping @PrePersist/@PostLoad/@PreLoad/@PostPersist callbacks for CritterMapper.

--- a/core/src/test/java/dev/morphia/mapping/TestCritterMapper.java
+++ b/core/src/test/java/dev/morphia/mapping/TestCritterMapper.java
@@ -234,7 +234,33 @@ public class TestCritterMapper {
                 "Static getter must not be exposed as a property");
     }
 
+    @Test
+    public void testSubclassGetterShadowsSuperclassGetter() {
+        CritterMapper mapper = new CritterMapper(
+                MorphiaConfig.load().mapper(MapperType.CRITTER).propertyDiscovery(PropertyDiscovery.METHODS));
+        EntityModel model = mapper.mapEntity(OverridingChild.class);
+        Assertions.assertNotNull(model.getProperty("value"),
+                "Property must be discovered when both subclass and superclass define the getter");
+        OverridingChild instance = new OverridingChild();
+        model.getProperty("value").getAccessor().set(instance, "x");
+        Assertions.assertEquals("OVERRIDDEN:x", model.getProperty("value").getAccessor().get(instance),
+                "Subclass getter must take precedence over superclass getter");
+    }
+
+    @Test
+    public void testGrandparentSetterDiscovered() {
+        CritterMapper mapper = new CritterMapper(
+                MorphiaConfig.load().mapper(MapperType.CRITTER).propertyDiscovery(PropertyDiscovery.METHODS));
+        EntityModel model = mapper.mapEntity(GrandChild.class);
+        Assertions.assertNotNull(model.getProperty("data"),
+                "Setter defined only in grandparent must be found via hierarchy walk");
+        GrandChild instance = new GrandChild();
+        model.getProperty("data").getAccessor().set(instance, "test");
+        Assertions.assertEquals("test", model.getProperty("data").getAccessor().get(instance));
+    }
+
     public static class MethodsBase {
+        // transient: excluded from field-based discovery so only METHODS mode maps this property
         private transient String name;
 
         public String getName() {
@@ -305,5 +331,50 @@ public class TestCritterMapper {
         @PrePersist
         public void prePersist() {
         }
+    }
+
+    public static class OverridingBase {
+        private transient String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    @Entity("overriding_child")
+    public static class OverridingChild extends OverridingBase {
+        @Id
+        ObjectId id;
+
+        @Override
+        public String getValue() {
+            String raw = super.getValue();
+            return raw == null ? null : "OVERRIDDEN:" + raw;
+        }
+    }
+
+    public static class GrandParent {
+        private transient String data;
+
+        public String getData() {
+            return data;
+        }
+
+        public void setData(String data) {
+            this.data = data;
+        }
+    }
+
+    public static class MiddleParent extends GrandParent {
+    }
+
+    @Entity("grand_child")
+    public static class GrandChild extends MiddleParent {
+        @Id
+        ObjectId id;
     }
 }


### PR DESCRIPTION
## Summary

- `discoverPropertyMethods()` only inspected the immediate `ClassNode`, so getter/setter pairs declared in parent classes were silently omitted when `PropertyDiscovery.METHODS` was active
- A child entity whose property accessors come entirely from a base class would have zero properties mapped under METHODS mode
- Fix walks the superclass chain the same way `discoverAllFields()` already does; subclass overrides take precedence via a `seen` map

## Test plan

- [ ] `TestCritterMapper#testInheritedGetterDiscoveryInMethodsMode` — new test with `MethodsBase` (defines `getName`/`setName`) and `MethodsChild extends MethodsBase` (`@Entity`); verifies `name` property is discovered
- [ ] All 12 `TestCritterMapper` tests pass

https://claude.ai/code/session_01788qAtGdn41QnwBvd8JeJr

---
_Generated by [Claude Code](https://claude.ai/code/session_01788qAtGdn41QnwBvd8JeJr)_