### PR TITLE
Consolidate duplicate emitTypeData/emitClassRef into GizmoExtensions

### DIFF
--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoExtensions.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoExtensions.java
@@ -95,6 +95,31 @@ public class GizmoExtensions {
     }
 
     /**
+     * Emits Gizmo bytecode that loads a {@link Class} reference. Non-public classes (e.g. private
+     * inner classes) cannot be referenced via an LDC constant from a different classloader, so this
+     * generates a {@code Class.forName()} call in that case.
+     *
+     * @param methodCreator the Gizmo method creator in which the bytecode is emitted
+     * @param cls           the class to load
+     * @return a result handle for the class reference
+     */
+    public static ResultHandle emitClassRef(MethodCreator methodCreator, Class<?> cls) {
+        if (java.lang.reflect.Modifier.isPublic(cls.getModifiers())) {
+            return methodCreator.loadClass(cls);
+        }
+        ResultHandle name = methodCreator.load(cls.getName());
+        ResultHandle falseHandle = methodCreator.load(false);
+        ResultHandle thread = methodCreator.invokeStaticMethod(
+                ofMethod(Thread.class, "currentThread", Thread.class));
+        ResultHandle tccl = methodCreator.invokeVirtualMethod(
+                ofMethod(Thread.class, "getContextClassLoader", ClassLoader.class),
+                thread);
+        return methodCreator.invokeStaticMethod(
+                ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
+                name, falseHandle, tccl);
+    }
+
+    /**
      * Emits Gizmo bytecode that constructs a {@link TypeData} instance matching the given type data.
      *
      * @param data          the type data to emit
@@ -108,7 +133,7 @@ public class GizmoExtensions {
             methodCreator.writeArrayValue(array, index, emitTypeData(typeParameters.get(index), methodCreator));
         }
         List<ResultHandle> list = new ArrayList<>();
-        list.add(methodCreator.loadClass(data.getType()));
+        list.add(emitClassRef(methodCreator, data.getType()));
         list.add(array);
         MethodDescriptor descriptor = MethodDescriptor.ofConstructor(
                 TypeData.class,

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
@@ -279,7 +279,7 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
 
     private void getType() {
         try (MethodCreator methodCreator = getCreator().getMethodCreator("getType", Class.class)) {
-            methodCreator.returnValue(emitClassRef(methodCreator, getTypeData().getType()));
+            methodCreator.returnValue(GizmoExtensions.emitClassRef(methodCreator, getTypeData().getType()));
         }
     }
 
@@ -292,45 +292,8 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
 
     private void emitGetTypeData() {
         try (MethodCreator methodCreator = getCreator().getMethodCreator("getTypeData", TypeData.class)) {
-            methodCreator.returnValue(emitTypeData(methodCreator, this.getTypeData()));
+            methodCreator.returnValue(GizmoExtensions.emitTypeData(this.getTypeData(), methodCreator));
         }
-    }
-
-    private ResultHandle emitTypeData(MethodCreator methodCreator, TypeData<?> data) {
-        ResultHandle array = methodCreator.newArray(TypeData.class, data.getTypeParameters().size());
-        List<TypeData<?>> typeParameters = data.getTypeParameters();
-        for (int index = 0; index < typeParameters.size(); index++) {
-            methodCreator.writeArrayValue(array, index, emitTypeData(methodCreator, typeParameters.get(index)));
-        }
-        List<ResultHandle> list = new ArrayList<>();
-        list.add(emitClassRef(methodCreator, data.getType()));
-        list.add(array);
-        MethodDescriptor descriptor = MethodDescriptor.ofConstructor(
-                TypeData.class,
-                Class.class,
-                "[" + Type.getType(TypeData.class).getDescriptor());
-        return methodCreator.newInstance(descriptor, list.toArray(new ResultHandle[0]));
-    }
-
-    /**
-     * Emits bytecode to load a {@link Class} reference. For non-public classes (e.g. private
-     * inner classes) that cannot be referenced via an LDC constant from a different classloader,
-     * generates a {@code Class.forName()} call instead.
-     */
-    private ResultHandle emitClassRef(MethodCreator methodCreator, Class<?> cls) {
-        if (java.lang.reflect.Modifier.isPublic(cls.getModifiers())) {
-            return methodCreator.loadClass(cls);
-        }
-        ResultHandle name = methodCreator.load(cls.getName());
-        ResultHandle falseHandle = methodCreator.load(false);
-        ResultHandle thread = methodCreator.invokeStaticMethod(
-                ofMethod(Thread.class, "currentThread", Thread.class));
-        ResultHandle tccl = methodCreator.invokeVirtualMethod(
-                ofMethod(Thread.class, "getContextClassLoader", ClassLoader.class),
-                thread);
-        return methodCreator.invokeStaticMethod(
-                ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
-                name, falseHandle, tccl);
     }
 
     private void isCollection() {
@@ -370,7 +333,7 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
     private void getNormalizedType() {
         try (MethodCreator methodCreator = getCreator().getMethodCreator("getNormalizedType", Class.class)) {
             Class<?> normalizedType = PropertyModel.normalize(getTypeData());
-            methodCreator.returnValue(emitClassRef(methodCreator, normalizedType));
+            methodCreator.returnValue(GizmoExtensions.emitClassRef(methodCreator, normalizedType));
         }
     }
 


### PR DESCRIPTION
## Summary

- `PropertyModelGenerator` had private copies of `emitTypeData()` and `emitClassRef()` that duplicated logic already present (or belonging) in `GizmoExtensions`
- Move `emitClassRef()` to `GizmoExtensions` as a public static method (it was already needed for the entity model generator to handle non-public entity classes)
- Remove the private copies from `PropertyModelGenerator` and update all three call sites to use `GizmoExtensions.*`
- `GizmoExtensions.emitTypeData()` already existed; the duplicate in `PropertyModelGenerator` is now deleted

## Test plan

- [ ] `TestGizmoGeneration` — 8 tests pass, no regression in property model generation
- [ ] `TestCritterMapper` — 11 tests pass

https://claude.ai/code/session_01788qAtGdn41QnwBvd8JeJr

---
_Generated by [Claude Code](https://claude.ai/code/session_01788qAtGdn41QnwBvd8JeJr)_