### PR TITLE
Replace hand-rolled generic signature parser with ASM SignatureReader

### DIFF
--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoExtensions.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/GizmoExtensions.java
@@ -95,6 +95,31 @@ public class GizmoExtensions {
     }
 
     /**
+     * Emits Gizmo bytecode that loads a {@link Class} reference. Non-public classes (e.g. private
+     * inner classes) cannot be referenced via an LDC constant from a different classloader, so this
+     * generates a {@code Class.forName()} call in that case.
+     *
+     * @param methodCreator the Gizmo method creator in which the bytecode is emitted
+     * @param cls           the class to load
+     * @return a result handle for the class reference
+     */
+    public static ResultHandle emitClassRef(MethodCreator methodCreator, Class<?> cls) {
+        if (java.lang.reflect.Modifier.isPublic(cls.getModifiers())) {
+            return methodCreator.loadClass(cls);
+        }
+        ResultHandle name = methodCreator.load(cls.getName());
+        ResultHandle falseHandle = methodCreator.load(false);
+        ResultHandle thread = methodCreator.invokeStaticMethod(
+                ofMethod(Thread.class, "currentThread", Thread.class));
+        ResultHandle tccl = methodCreator.invokeVirtualMethod(
+                ofMethod(Thread.class, "getContextClassLoader", ClassLoader.class),
+                thread);
+        return methodCreator.invokeStaticMethod(
+                ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
+                name, falseHandle, tccl);
+    }
+
+    /**
      * Emits Gizmo bytecode that constructs a {@link TypeData} instance matching the given type data.
      *
      * @param data          the type data to emit
@@ -108,7 +133,7 @@ public class GizmoExtensions {
             methodCreator.writeArrayValue(array, index, emitTypeData(typeParameters.get(index), methodCreator));
         }
         List<ResultHandle> list = new ArrayList<>();
-        list.add(methodCreator.loadClass(data.getType()));
+        list.add(emitClassRef(methodCreator, data.getType()));
         list.add(array);
         MethodDescriptor descriptor = MethodDescriptor.ofConstructor(
                 TypeData.class,

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
@@ -279,7 +279,7 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
 
     private void getType() {
         try (MethodCreator methodCreator = getCreator().getMethodCreator("getType", Class.class)) {
-            methodCreator.returnValue(emitClassRef(methodCreator, getTypeData().getType()));
+            methodCreator.returnValue(GizmoExtensions.emitClassRef(methodCreator, getTypeData().getType()));
         }
     }
 
@@ -292,45 +292,8 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
 
     private void emitGetTypeData() {
         try (MethodCreator methodCreator = getCreator().getMethodCreator("getTypeData", TypeData.class)) {
-            methodCreator.returnValue(emitTypeData(methodCreator, this.getTypeData()));
+            methodCreator.returnValue(GizmoExtensions.emitTypeData(this.getTypeData(), methodCreator));
         }
-    }
-
-    private ResultHandle emitTypeData(MethodCreator methodCreator, TypeData<?> data) {
-        ResultHandle array = methodCreator.newArray(TypeData.class, data.getTypeParameters().size());
-        List<TypeData<?>> typeParameters = data.getTypeParameters();
-        for (int index = 0; index < typeParameters.size(); index++) {
-            methodCreator.writeArrayValue(array, index, emitTypeData(methodCreator, typeParameters.get(index)));
-        }
-        List<ResultHandle> list = new ArrayList<>();
-        list.add(emitClassRef(methodCreator, data.getType()));
-        list.add(array);
-        MethodDescriptor descriptor = MethodDescriptor.ofConstructor(
-                TypeData.class,
-                Class.class,
-                "[" + Type.getType(TypeData.class).getDescriptor());
-        return methodCreator.newInstance(descriptor, list.toArray(new ResultHandle[0]));
-    }
-
-    /**
-     * Emits bytecode to load a {@link Class} reference. For non-public classes (e.g. private
-     * inner classes) that cannot be referenced via an LDC constant from a different classloader,
-     * generates a {@code Class.forName()} call instead.
-     */
-    private ResultHandle emitClassRef(MethodCreator methodCreator, Class<?> cls) {
-        if (java.lang.reflect.Modifier.isPublic(cls.getModifiers())) {
-            return methodCreator.loadClass(cls);
-        }
-        ResultHandle name = methodCreator.load(cls.getName());
-        ResultHandle falseHandle = methodCreator.load(false);
-        ResultHandle thread = methodCreator.invokeStaticMethod(
-                ofMethod(Thread.class, "currentThread", Thread.class));
-        ResultHandle tccl = methodCreator.invokeVirtualMethod(
-                ofMethod(Thread.class, "getContextClassLoader", ClassLoader.class),
-                thread);
-        return methodCreator.invokeStaticMethod(
-                ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
-                name, falseHandle, tccl);
     }
 
     private void isCollection() {
@@ -370,7 +333,7 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
     private void getNormalizedType() {
         try (MethodCreator methodCreator = getCreator().getMethodCreator("getNormalizedType", Class.class)) {
             Class<?> normalizedType = PropertyModel.normalize(getTypeData());
-            methodCreator.returnValue(emitClassRef(methodCreator, normalizedType));
+            methodCreator.returnValue(GizmoExtensions.emitClassRef(methodCreator, normalizedType));
         }
     }
 

--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
@@ -28,6 +28,8 @@ import dev.morphia.mapping.codec.pojo.critter.CritterPropertyModel;
 import org.bson.codecs.pojo.PropertyAccessor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.signature.SignatureReader;
+import org.objectweb.asm.signature.SignatureVisitor;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.MethodNode;
@@ -421,72 +423,115 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
 
     // ---- Static utility methods (formerly package-level functions) ----
 
-    private static String balanced(String s) {
-        if (!s.contains("<"))
-            return "";
-        int start = s.indexOf('<') + 1;
-        int index = start;
-        int count = 1;
-
-        while (index < s.length() && count != 0) {
-            char c = s.charAt(++index);
-            if (c == '>')
-                count--;
-            else if (c == '<')
-                count++;
-        }
-
-        return s.substring(start, index);
-    }
-
     /**
      * Parses an ASM type signature string into a list of {@link TypeData} instances.
      *
-     * @param input       the ASM type signature to parse
+     * @param input       the ASM type signature to parse (field/return-type signature)
      * @param classLoader the class loader used to resolve referenced types
-     * @return the list of type data values parsed from the signature
+     * @return a single-element list containing the parsed type data, or empty if parsing fails
      */
     public static List<TypeData<?>> typeData(String input, ClassLoader classLoader) {
         if (input.isEmpty())
             return Collections.emptyList();
-        List<TypeData<?>> types = new ArrayList<>();
-        String value = input;
+        TypeDataVisitor visitor = new TypeDataVisitor(classLoader);
+        new SignatureReader(input).acceptType(visitor);
+        return visitor.result != null ? List.of(visitor.result) : Collections.emptyList();
+    }
 
-        while (!value.isEmpty()) {
-            // Strip wildcard bound prefixes (+ = extends, - = super, * = unbounded)
-            if (value.startsWith("+") || value.startsWith("-")) {
-                value = value.substring(1);
-                continue;
-            }
-            if (value.startsWith("*")) {
-                value = value.substring(1);
-                types.add(GizmoExtensions.typeDataFromType(Type.getType(Object.class), classLoader));
-                continue;
-            }
-            int bracket = value.indexOf('<');
-            int semicolon = value.indexOf(';');
-            // Handle type parameters (e.g., TT; for type param T) - use Object as erasure
-            if (value.startsWith("T") && !value.startsWith("T[")) {
-                value = (semicolon != -1) ? value.substring(semicolon + 1) : "";
-                types.add(GizmoExtensions.typeDataFromType(Type.getType(Object.class), classLoader));
-            } else if (bracket == -1 || (semicolon != -1 && bracket > semicolon)) {
-                String type = value.substring(0, semicolon != -1 ? semicolon : value.length());
-                boolean hadSemicolon = semicolon != -1 && semicolon < value.length();
-                if (hadSemicolon && type.length() > 2) {
-                    type += ";";
+    private static class TypeDataVisitor extends SignatureVisitor {
+        private final ClassLoader classLoader;
+        TypeData<?> result;
+
+        private String pendingClass;
+        private final List<TypeDataVisitor> typeArgVisitors = new ArrayList<>();
+
+        TypeDataVisitor(ClassLoader classLoader) {
+            super(Opcodes.ASM9);
+            this.classLoader = classLoader;
+        }
+
+        @Override
+        public void visitClassType(String name) {
+            pendingClass = "L" + name + ";";
+            typeArgVisitors.clear();
+        }
+
+        @Override
+        public void visitInnerClassType(String name) {
+            // Strip trailing ';' and append '$Name;'
+            pendingClass = pendingClass.substring(0, pendingClass.length() - 1) + "$" + name + ";";
+        }
+
+        @Override
+        public SignatureVisitor visitTypeArgument(char wildcard) {
+            TypeDataVisitor child = new TypeDataVisitor(classLoader);
+            typeArgVisitors.add(child);
+            return child;
+        }
+
+        @Override
+        public void visitTypeArgument() {
+            // Unbounded wildcard '*': use Object as erasure
+            TypeDataVisitor child = new TypeDataVisitor(classLoader);
+            child.result = new TypeData<>(Object.class, List.of());
+            typeArgVisitors.add(child);
+        }
+
+        @Override
+        public void visitTypeVariable(String name) {
+            result = new TypeData<>(Object.class, List.of());
+        }
+
+        @Override
+        public void visitBaseType(char descriptor) {
+            result = GizmoExtensions.typeDataFromType(Type.getType(String.valueOf(descriptor)), classLoader);
+        }
+
+        @Override
+        public SignatureVisitor visitArrayType() {
+            TypeDataVisitor outer = this;
+            return new TypeDataVisitor(classLoader) {
+                private void propagate() {
+                    if (this.result != null) {
+                        try {
+                            Class<?> arrayClass = java.lang.reflect.Array.newInstance(this.result.getType(), 0)
+                                    .getClass();
+                            outer.result = new TypeData<>(arrayClass, List.of());
+                        } catch (Exception ignored) {
+                            outer.result = new TypeData<>(Object.class, List.of());
+                        }
+                    }
                 }
-                value = hadSemicolon ? value.substring(type.length()) : "";
-                types.add(GizmoExtensions.typeDataFromType(Type.getType(type), classLoader));
-            } else {
-                String paramString = balanced(value);
-                value = value.replace("<" + paramString + ">", "");
-                types.add(GizmoExtensions.typeDataFromType(
-                        Type.getType(value),
-                        classLoader,
-                        typeData(paramString, classLoader)));
-                value = value.contains(";") ? value.substring(value.indexOf(';') + 1) : "";
+
+                @Override
+                public void visitBaseType(char descriptor) {
+                    super.visitBaseType(descriptor);
+                    propagate();
+                }
+
+                @Override
+                public void visitEnd() {
+                    super.visitEnd();
+                    propagate();
+                }
+
+                @Override
+                public void visitTypeVariable(String name) {
+                    super.visitTypeVariable(name);
+                    propagate();
+                }
+            };
+        }
+
+        @Override
+        public void visitEnd() {
+            if (pendingClass != null) {
+                List<TypeData<?>> params = typeArgVisitors.stream()
+                        .map(v -> v.result != null ? v.result : new TypeData<>(Object.class, List.of()))
+                        .toList();
+                result = GizmoExtensions.typeDataFromType(Type.getType(pendingClass), classLoader, params);
+                pendingClass = null;
             }
         }
-        return types;
     }
 }


### PR DESCRIPTION
## Summary

- `PropertyModelGenerator.typeData()` used a manual while-loop with a custom bracket-counter (`balanced()`) and fragile string-slice operations to parse generic field/return-type signatures like `Ljava/util/Map<Ljava/lang/String;...;>;`
- Replace with ASM's `SignatureReader` + a `SignatureVisitor` subclass (`TypeDataVisitor`) that builds the `TypeData` tree through the natural visitor call hierarchy:
  - `visitClassType`/`visitEnd` pairs build class-type `TypeData` with their type parameters
  - `visitTypeArgument` callbacks collect each type parameter as a child visitor
  - `visitTypeVariable` maps type variables to `Object` (erasure), same as before
  - `visitArrayType` wraps the component type in an array class
  - `visitBaseType` handles primitive types
- Removes ~50 lines of brittle parsing (including `balanced()` helper)

## Test plan

- [ ] `TestGizmoGeneration#testMapStringExample` — `Map<String, Example>`
- [ ] `TestGizmoGeneration#testListMapStringExample` — `List<Map<String, Example>>`
- [ ] `TestGizmoGeneration#testMapOfList` — `Map<String, List<Example>>`
- [ ] `TestGizmoGeneration#testPrimitiveArray` — `int[]`
- [ ] All 8 `TestGizmoGeneration` tests pass
- [ ] All 11 `TestCritterMapper` tests pass

https://claude.ai/code/session_01788qAtGdn41QnwBvd8JeJr

---
_Generated by [Claude Code](https://claude.ai/code/session_01788qAtGdn41QnwBvd8JeJr)_