### PR TITLE
Fix two Copilot-identified bugs in TypeDataVisitor signature parsing

### DIFF
--- a/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
+++ b/core/src/main/java/dev/morphia/critter/parser/gizmo/PropertyModelGenerator.java
@@ -433,9 +433,13 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
     public static List<TypeData<?>> typeData(String input, ClassLoader classLoader) {
         if (input.isEmpty())
             return Collections.emptyList();
-        TypeDataVisitor visitor = new TypeDataVisitor(classLoader);
-        new SignatureReader(input).acceptType(visitor);
-        return visitor.result != null ? List.of(visitor.result) : Collections.emptyList();
+        try {
+            TypeDataVisitor visitor = new TypeDataVisitor(classLoader);
+            new SignatureReader(input).acceptType(visitor);
+            return visitor.result != null ? List.of(visitor.result) : Collections.emptyList();
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
     }
 
     private static class TypeDataVisitor extends SignatureVisitor {
@@ -489,38 +493,54 @@ public class PropertyModelGenerator extends BaseGizmoGenerator {
 
         @Override
         public SignatureVisitor visitArrayType() {
-            TypeDataVisitor outer = this;
-            return new TypeDataVisitor(classLoader) {
-                private void propagate() {
-                    if (this.result != null) {
-                        try {
-                            Class<?> arrayClass = java.lang.reflect.Array.newInstance(this.result.getType(), 0)
-                                    .getClass();
-                            outer.result = new TypeData<>(arrayClass, List.of());
-                        } catch (Exception ignored) {
-                            outer.result = new TypeData<>(Object.class, List.of());
-                        }
+            return new ArrayVisitor(classLoader, this);
+        }
+
+        private static class ArrayVisitor extends TypeDataVisitor {
+            private final TypeDataVisitor outer;
+
+            ArrayVisitor(ClassLoader classLoader, TypeDataVisitor outer) {
+                super(classLoader);
+                this.outer = outer;
+            }
+
+            private void propagate() {
+                if (result != null) {
+                    try {
+                        Class<?> arrayClass = java.lang.reflect.Array.newInstance(result.getType(), 0).getClass();
+                        outer.result = new TypeData<>(arrayClass, List.of());
+                    } catch (Exception ignored) {
+                        outer.result = new TypeData<>(Object.class, List.of());
+                    }
+                    // If outer is itself an ArrayVisitor, propagate the chain upward.
+                    if (outer instanceof ArrayVisitor av) {
+                        av.propagate();
                     }
                 }
+            }
 
-                @Override
-                public void visitBaseType(char descriptor) {
-                    super.visitBaseType(descriptor);
-                    propagate();
-                }
+            @Override
+            public void visitBaseType(char descriptor) {
+                super.visitBaseType(descriptor);
+                propagate();
+            }
 
-                @Override
-                public void visitEnd() {
-                    super.visitEnd();
-                    propagate();
-                }
+            @Override
+            public void visitEnd() {
+                super.visitEnd();
+                propagate();
+            }
 
-                @Override
-                public void visitTypeVariable(String name) {
-                    super.visitTypeVariable(name);
-                    propagate();
-                }
-            };
+            @Override
+            public void visitTypeVariable(String name) {
+                super.visitTypeVariable(name);
+                propagate();
+            }
+
+            @Override
+            public SignatureVisitor visitArrayType() {
+                return new ArrayVisitor(outer.classLoader, this);
+            }
         }
 
         @Override

--- a/core/src/test/java/dev/morphia/critter/parser/gizmo/TestGizmoGeneration.java
+++ b/core/src/test/java/dev/morphia/critter/parser/gizmo/TestGizmoGeneration.java
@@ -97,6 +97,21 @@ public class TestGizmoGeneration {
     }
 
     @Test
+    public void testMultiDimensionalArray() {
+        // int[][] — verifies that nested visitArrayType() calls propagate correctly
+        TypeData<?> typeData = PropertyModelGenerator.typeData("[[I", Thread.currentThread().getContextClassLoader()).get(0);
+        Assertions.assertTrue(typeData.isArray());
+        Assertions.assertEquals(int[][].class, typeData.getType());
+    }
+
+    @Test
+    public void testMalformedSignatureReturnsEmpty() {
+        // Malformed signatures must return empty rather than throw
+        var result = PropertyModelGenerator.typeData("!!not-a-valid-signature!!", Thread.currentThread().getContextClassLoader());
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
     public void testAnnotationBuilding() throws Exception {
         AnnotationNode index = new AnnotationNode("Ldev/morphia/annotations/Index;");
         AnnotationNode field = new AnnotationNode("Ldev/morphia/annotations/Field;");


### PR DESCRIPTION
## Summary

Addresses the two issues Copilot flagged on #4271:

**1. Exception safety in `typeData()` (Comment 1)**
`SignatureReader.acceptType()` can throw (e.g. `IllegalArgumentException`) for malformed signatures. The Javadoc promised an empty list on failure but the exception was propagating uncaught. Wrapped the parse call in `try/catch` to honour the contract.

**2. Multi-dimensional array propagation (Comment 2)**
The anonymous class returned by `visitArrayType()` did not override `visitArrayType()` itself, so for types like `int[][]` the propagation chain broke: the intermediate visitor set its own `result` (e.g. `int[]`) but nothing ever notified the root visitor, leaving `root.result == null`.

Fix: replaced the anonymous class with a named static inner class `ArrayVisitor` that:
- overrides `visitArrayType()` to return `new ArrayVisitor(classLoader, this)`, creating the full chain
- after setting `outer.result`, checks `if (outer instanceof ArrayVisitor av) av.propagate()` to continue propagation upward through arbitrary nesting depths

## Test plan

- All 8 `TestGizmoGeneration` tests pass
- All 11 `TestCritterMapper` tests pass

https://claude.ai/code/session_0154ibJQXuJaDWqUxP2MLW7b
